### PR TITLE
Scale Home Assistant statefulset to zero replicas

### DIFF
--- a/kubernetes/deploy/home/home-automation/homeassistant/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/home-automation/homeassistant/clusters/bastion/values.yaml
@@ -6,6 +6,7 @@ defaultPodOptions:
 controllers:
   main:
     type: statefulset
+    replicas: 0
     pod:
       annotations:
         k8s.v1.cni.cncf.io/networks: |-


### PR DESCRIPTION
## Summary
- set the Home Assistant bastion overlay to use zero replicas so the statefulset scales down

## Testing
- `task apps:overlays:render project=home namespace=home-automation app=homeassistant cluster=bastion` *(fails: unable to download https://bjw-s-labs.github.io/helm-charts/ index due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c973f2b5c08333bafb2e5557b5f358