### PR TITLE
ci: integrate Tailscale with GitHub Actions using workload identity federation

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -9,13 +9,17 @@ jobs:
   argocd-diff:
     name: Generate ArgoCD Diff
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: tailscale/github-action@v4
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ghactions
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: ${{ vars.TAILSCALE_TAGS || 'tag:ghactions' }}
           # renovate: datasource=github-releases depName=tailscale/tailscale
           version: 1.60.1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: ${{ vars.TAILSCALE_TAGS || 'tag:ghactions' }}
+          # renovate: datasource=github-releases depName=tailscale/tailscale
+          version: 1.60.1
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ vars.TAILSCALE_OAUTH_CLIENT_ID }}
+          audience: ${{ vars.TAILSCALE_AUDIENCE }}
+          tags: ${{ vars.TAILSCALE_TAGS || 'tag:ghactions' }}
+          # renovate: datasource=github-releases depName=tailscale/tailscale
+          version: 1.60.1
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary

This PR implements Tailscale integration across all major GitHub Actions workflows using workload identity federation (OIDC) instead of OAuth secrets, as requested in #510.

## Changes

### Modified Workflows

1. **argocd-diff.yml** (.github/workflows/argocd-diff.yml:9-23)
   - Migrated from OAuth secrets to OIDC authentication
   - Added required permissions block with `id-token: write`
   - Replaced `oauth-client-id` and `oauth-secret` with `oidc-audience`
   - Now uses workflow variables instead of secrets

2. **claude.yml** (.github/workflows/claude.yml:33-39)
   - Added Tailscale connection step after checkout
   - Positioned early in workflow to ensure connectivity before Claude operations
   - Already had `id-token: write` permission required for OIDC

3. **claude-code-review.yml** (.github/workflows/claude-code-review.yml:34-40)
   - Added Tailscale connection step after checkout
   - Positioned early in workflow for tailnet access during reviews
   - Already had `id-token: write` permission required for OIDC

### Key Implementation Details

- **No new secrets**: All configuration uses workflow variables
- **Early execution**: Tailscale connection happens immediately after checkout
- **Consistent versioning**: Using Tailscale v1.60.1 across all workflows (managed by Renovate)
- **Flexible tagging**: Defaults to `tag:ghactions` but can be overridden via variable

## Security Benefits

✅ No long-lived secrets stored in GitHub  
✅ Automatic token rotation via OIDC  
✅ Better audit trail (tokens tied to specific workflow runs)  
✅ Reduced risk if GitHub Actions logs are compromised  

## Setup Required

Before merging, configure these repository variables:

1. **TAILSCALE_OAUTH_CLIENT_ID** (required)
   - Obtain from [Tailscale Admin Console](https://login.tailscale.com/admin/settings/oauth)
   - Create OAuth client with workload identity federation enabled
   - Format: `tsoc-client-xxxxxxxxxxxxx-yyyyyyyyyyyyyyy`

2. **TAILSCALE_TAGS** (optional)
   - Defaults to `tag:ghactions` if not set
   - Used to tag Tailscale nodes created by GitHub Actions

### Post-Merge Cleanup

After verifying workflows succeed:
- Remove old secrets: `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET`

## Testing

The workflows will be tested automatically on this PR by the ArgoCD diff workflow, which now uses OIDC authentication.

## References

- [Tailscale Workload Identity Federation Guide](https://tailscale.com/kb/1581/workload-identity-federation)
- [Tailscale GitHub Action](https://github.com/tailscale/github-action)
- Issue #510

Fixes #510

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)