### PR TITLE
feat(argocd): enable automatic deletion of disabled application overlays

### DIFF
--- a/.taskfiles/apps/overlay/Taskfile.yaml
+++ b/.taskfiles/apps/overlay/Taskfile.yaml
@@ -109,6 +109,11 @@ tasks:
     summary: |
       This task will disable an existing, enabled kustomize overlay targeting a specific cluster.
 
+      WARNING: With automatic deletion enabled, this will cause ArgoCD to DELETE
+      the application and all its resources from the cluster after the change is merged.
+
+      Use `task apps:overlay:status` first to see what will be deleted.
+
       Common arguments (project, namespace, app, cluster) can be explicitly provided or interactively selected.
 
       Example: disable the 'multus' app overlay in the 'kube-system' namespace targeting the 'cluster1' cluster.
@@ -117,12 +122,26 @@ tasks:
       Example: disable a cluster addon that targets all clusters.
         task apps:overlay:disable project=system namespace=kube-system app=volsync cluster=_all
     interactive: true
-    silent: true
+    silent: false
     vars: *allvars
     cmds:
+      - echo "⚠️  WARNING: Disabling this overlay will cause ArgoCD to DELETE the application!"
+      - echo "Application: {{.app}}-{{.cluster}}"
+      - echo ""
+      - echo "Fetching current application status..."
+      - argocd app get "{{.app}}-{{.cluster}}" -o tree || echo "Application not found (may already be deleted)"
+      - echo ""
+      - |
+        read -p "Continue with disable? This will DELETE the application after merge. (yes/no): " confirm
+        if [ "$confirm" != "yes" ]; then
+          echo "Disable cancelled"
+          exit 1
+        fi
       - mkdir -p "{{.disabledPath}}"
       - mv "{{.enabledPath}}/{{.cluster}}" "{{.disabledPath}}/"
-      - echo "Disabled overlay at {{.disabledPath}}/{{.cluster}}"
+      - echo "✓ Disabled overlay at {{.disabledPath}}/{{.cluster}}"
+      - echo ""
+      - echo "NOTE: After merging this change, ArgoCD will delete the application from the cluster"
     preconditions:
       - sh: test -f "{{.enabledPath}}/{{.cluster}}/kustomization.yaml"
         msg: "App overlay doesn't exist or isn't enabled."
@@ -293,3 +312,21 @@ tasks:
     preconditions:
       - sh: test -f "{{.overlayPath}}/kustomization.yaml"
         msg: "App overlay doesn't exist."
+  orphaned:
+    desc: "List orphaned ArgoCD applications"
+    summary: |
+      Lists ArgoCD applications that exist in the cluster but don't have
+      corresponding enabled overlays in git (likely in disabled/).
+    silent: false
+    cmds:
+      - |
+        echo "Checking for orphaned ArgoCD applications..."
+        argocd app list -o name | grep -v "^argocd/" | while read app; do
+          cluster=$(echo "$app" | rev | cut -d'-' -f1 | rev)
+          appname=$(echo "$app" | rev | cut -d'-' -f2- | rev)
+          found=$(find kubernetes/deploy -path "*/clusters/${cluster}/kustomization.yaml" | \
+                  grep "/${appname}/clusters/${cluster}/" || echo "")
+          if [ -z "$found" ]; then
+            echo "ORPHANED: $app"
+          fi
+        done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,26 @@ Path segments map to ArgoCD Application properties:
 - **app**: `{app}` (segment 4) - Application name
 - **cluster**: `{cluster}` (segment 6) - Target cluster name
 
+#### Important: Automatic Deletion Behavior
+
+The ApplicationSet is configured with `applicationsSync: sync`, which means:
+- **Moving an overlay from `clusters/` to `disabled/` will cause ArgoCD to automatically DELETE the application**
+- The application and all its Kubernetes resources will be removed from the cluster
+- This happens automatically after the change is merged to the main branch
+
+**Safety Guidelines:**
+1. Always use `task apps:overlay:disable` instead of manual `git mv` commands
+2. The disable task will show you what resources will be deleted and require confirmation
+3. Use `task apps:overlay:status` to check the current state before disabling
+4. PR reviews and ArgoCD diff workflow will show deletions before merge
+5. To temporarily disable without deleting, consider commenting out in a kustomization instead
+
+**Checking for Orphaned Applications:**
+If applications exist in ArgoCD but not in git, use:
+```bash
+task apps:overlay:orphaned
+```
+
 #### Task Command Arguments
 Most `task apps:*` commands accept these parameters (can be provided or interactively selected):
 - **project**: ArgoCD project name (admin, database, home, misc, monitoring, system)

--- a/kubernetes/argocd/appsets/apps.yaml
+++ b/kubernetes/argocd/appsets/apps.yaml
@@ -4,8 +4,12 @@ metadata:
   name: apps
   namespace: argocd
 spec:
+  # syncPolicy controls how the ApplicationSet manages Application resources
+  # 'sync' (default): Allows create, update, and delete operations
+  # This ensures git is the source of truth - when overlays move to disabled/,
+  # the corresponding Applications are automatically deleted from ArgoCD
   syncPolicy:
-    applicationsSync: create-update
+    applicationsSync: sync  # Changed from create-update
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy


### PR DESCRIPTION
## Summary
Enables automatic deletion of ArgoCD applications when their overlays are moved to `disabled/` directories, implementing a true GitOps approach where git is the source of truth.

## Changes
- ✅ Updated ApplicationSet `applicationsSync` policy from `create-update` to `sync`
- ✅ Added `task apps:overlay:orphaned` command to detect orphaned applications
- ✅ Enhanced `task apps:overlay:disable` with warnings and confirmation prompts
- ✅ Added comprehensive documentation to CLAUDE.md about automatic deletion behavior

## Expected Impact
After this PR is merged, ArgoCD should automatically clean up the **17 orphaned applications** that exist from previously disabled overlays:

**Home Project (8):** wolf-bastion, capi-testing-bastion, ollama-bastion, gow-bastion, nats-bastion, homeassistant-bastion, esphome-bastion, wyze-bridge-bastion

**System Project (3):** democratic-csi-iscsi-bastion, democratic-csi-nfs-bastion, smb-rwx-mounts-bastion

**Monitoring Project (1):** minio-monitoring-tenant-bastion

**Admin/CAPI Project (5):** capi-core-bastion, capi-bootstrap-provider-talos-bastion, capi-cp-provider-talos-bastion, capi-byoh-bastion, capi-operator-bastion

## Safety Mechanisms
1. **Enhanced disable task** - Shows warnings and requires confirmation before disabling
2. **Orphaned detection** - New task command to identify applications without overlays
3. **PR reviews** - All changes go through PR review process
4. **ArgoCD diff** - CI/CD workflow will show deletions in PR comments
5. **Documentation** - Clear warnings in CLAUDE.md about automatic deletion

## Testing Plan
After merge:
1. Monitor ArgoCD for automatic deletion of orphaned apps
2. Run `task apps:overlay:orphaned` to verify cleanup
3. Test the enhanced disable workflow with a test application

## Rollback Plan
If issues occur, revert the ApplicationSet change:
```yaml
applicationsSync: create-update
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)