### PR TITLE
fix(cilium): add resource limits to prevent OOMKilled restarts

### DIFF
--- a/kubernetes/clusters/bastion/cni/values.yaml
+++ b/kubernetes/clusters/bastion/cni/values.yaml
@@ -84,6 +84,12 @@ localRedirectPolicy: true
 operator:
   rollOutPods: true
 rollOutCiliumPods: true
+resources:
+  limits:
+    memory: 2Gi
+  requests:
+    memory: 1Gi
+    cpu: 500m
 securityContext:
   privileged: true
 routingMode: tunnel


### PR DESCRIPTION
## Summary
- Add memory limits (2Gi) and requests (1Gi) to cilium-agent containers
- Add CPU request (500m) for better scheduling
- Prevents OOMKilled restarts on nodes

## Problem
The cilium-agent pods are experiencing OOMKilled restarts due to missing resource limits:
- talos-master-0: 15 restarts
- talos-master-2: Recently OOMKilled (exit code 137)
- Current memory usage ranges from 467Mi to 716Mi

## Solution
Set explicit resource limits with headroom for memory spikes:
- Memory limit: 2Gi (provides ~3x headroom over current usage)
- Memory request: 1Gi (ensures sufficient allocation)
- CPU request: 500m (improves scheduling)

## Test Plan
- [ ] ArgoCD sync and verify cilium pods restart successfully
- [ ] Monitor memory usage over 24-48 hours
- [ ] Verify no OOMKilled restarts occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)