### PR TITLE
fix(metamcp): patched image to fix subprocess leak

### DIFF
--- a/kubernetes/deploy/home/metamcp/metamcp/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/metamcp/metamcp/clusters/bastion/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             limits:
               memory: 128Mi
         - name: install-arr-suite-and-deno
-          image: ghcr.io/metatool-ai/metamcp:latest
+          image: ghcr.io/jtcressy-home/metamcp:patched@sha256:9b6e0a664616a97773f39fb50e8acb318d8f9abd8ce9eba60ff20669c72296c9
           command:
             - sh
             - -c
@@ -101,10 +101,25 @@ spec:
               memory: 1Gi
       containers:
         - name: metamcp
-          image: ghcr.io/metatool-ai/metamcp:latest
+          image: ghcr.io/jtcressy-home/metamcp:patched@sha256:9b6e0a664616a97773f39fb50e8acb318d8f9abd8ce9eba60ff20669c72296c9
           ports:
             - containerPort: 12008
               name: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 12008
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 12008
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
           env:
             # Database
             - name: DATABASE_URL


### PR DESCRIPTION
## Summary

- Switch MetaMCP image from upstream `latest` to a patched build from [metatool-ai/metamcp PR #273](https://github.com/metatool-ai/metamcp/pull/273), which fixes STDIO subprocess lifecycle race conditions
- Pin image by digest for reproducibility
- Add liveness/readiness probes using existing `/health` endpoint

## Root Cause

MetaMCP v2.4.22 has three confirmed subprocess leak bugs ([#128](https://github.com/metatool-ai/metamcp/issues/128), [#272](https://github.com/metatool-ai/metamcp/issues/272), [#273](https://github.com/metatool-ai/metamcp/pull/273)) that cause orphaned stdio child processes to accumulate. Diagnostics on the running pod showed **7 orphaned mcpvault process trees consuming 1.1GB** of the 2GB container limit after just 6 hours, causing intermittent MCP tool execution failures.

PR #273 fixes:
- SIGTERM fire-and-forget in `ProcessManagedStdioTransport` (now waits 5s, escalates to SIGKILL)
- Three race conditions in `McpServerPool` causing duplicate process spawns
- Includes PR #239 connection failure cleanup (already merged to upstream main)

## Test plan

- [ ] ArgoCD syncs successfully and pod starts with new image
- [ ] `kubectl exec ... -- ps aux | grep mcpvault` shows 1 instance, not 7
- [ ] `kubectl top pod ... --containers` shows memory well under 500MB
- [ ] Sustained MCP session from Claude.ai has no intermittent failures

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)