### PR TITLE
feat(openclaw): install openclaw-operator v0.28.0 on bastion

### DIFF
--- a/kubernetes/argocd/projects/admin.yaml
+++ b/kubernetes/argocd/projects/admin.yaml
@@ -27,6 +27,9 @@ spec:
     - namespace: 'byoh-system'
       name: '*'
       server: '*'
+    - namespace: 'openclaw-operator-system'
+      name: '*'
+      server: '*'
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/kubernetes/deploy/admin/openclaw-operator-system/openclaw-operator/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/admin/openclaw-operator-system/openclaw-operator/clusters/bastion/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openclaw-operator-system
+
+helmCharts:
+  - name: openclaw-operator
+    repo: oci://ghcr.io/openclaw-rocks/charts
+    version: 0.28.0
+    releaseName: openclaw-operator
+    namespace: openclaw-operator-system
+    includeCRDs: true
+    valuesInline:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+
+patches:
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+        value: ServerSideApply=true


### PR DESCRIPTION
## Summary

- Adds a new ArgoCD-managed overlay at `kubernetes/deploy/admin/openclaw-operator-system/openclaw-operator/clusters/bastion/` that installs the upstream [openclaw-operator](https://github.com/OpenClaw-rocks/openclaw-operator) Helm chart.
- Chart source: `oci://ghcr.io/openclaw-rocks/charts/openclaw-operator`, pinned at version **0.28.0** (Renovate will PR subsequent bumps).
- Namespace: `openclaw-operator-system` (new). Added as a destination on the `admin` AppProject.
- After merge + ArgoCD sync, the `OpenClawInstance` and `OpenClawSelfConfig` CRDs become available cluster-wide and the operator pod runs in the new namespace. This unblocks a follow-up task that deploys an `OpenClawInstance` CR.

## Configuration

- `replicaCount: 1` (single-node cluster)
- Resources: 100m/128Mi requests, 500m/512Mi limits
- `metrics.serviceMonitor.enabled: true` — VMAgent runs `selectAllByDefault: true` so the operator metrics get scraped automatically.
- CRDs installed via `includeCRDs: true`, annotated with `argocd.argoproj.io/sync-options: ServerSideApply=true` (matches the `cnpg` overlay pattern).

## Deviation from plan

- Task plan called for enabling a cert-manager-backed validating webhook. **The v0.28.0 chart ships no webhook templates** (`helm pull` + template inspection confirmed — only `deployment.yaml`, `metrics-*.yaml`, `rbac.yaml`, `serviceaccount.yaml`, and the two CRDs). `webhook.enabled` in `values.yaml` appears dormant. Webhook config was therefore omitted; no `ClusterIssuer`/`Issuer` wiring is needed at this time. If a future chart version adds webhook templates, a follow-up PR will wire it.
- Also note: the cluster has **no ClusterIssuers** — only namespaced `Issuer` resources (see `kubectl get clusterissuer`). Any future webhook wiring will use a namespaced self-signed `Issuer`, matching the `inteldeviceplugins-selfsigned-issuer` pattern already in `kube-system`.

## Verification plan (post-merge)

- [ ] ArgoCD app `openclaw-operator-bastion` reaches Healthy / Synced.
- [ ] `kubectl get crd openclawinstances.openclaw.rocks openclawselfconfigs.openclaw.rocks` — both present.
- [ ] `kubectl -n openclaw-operator-system get pods` — operator pod Running 1/1.
- [ ] `kubectl -n openclaw-operator-system logs deploy/openclaw-operator --tail=50` — leader election established, no panics.
- [ ] `kubectl -n openclaw-operator-system get servicemonitor openclaw-operator` — ServiceMonitor present and picked up by VMAgent.
- [ ] Webhook verification (ValidatingWebhookConfiguration, Certificate) is **N/A** for v0.28.0 per the deviation above.

## Rollback

1. `task apps:overlays:disable project=admin namespace=openclaw-operator-system app=openclaw-operator cluster=bastion`
2. Commit + push. ArgoCD prunes the Deployment and RBAC. CRDs persist (decoupled from operator lifecycle — matches upstream `keep: true`).
3. Manual CRD cleanup if fully backing out: `kubectl delete crd openclawinstances.openclaw.rocks openclawselfconfigs.openclaw.rocks`.
