### PR TITLE
feat(openclaw): deploy K8s gateway instance on bastion

### DIFF
--- a/kubernetes/argocd/projects/admin.yaml
+++ b/kubernetes/argocd/projects/admin.yaml
@@ -30,6 +30,12 @@ spec:
     - namespace: 'openclaw-operator-system'
       name: '*'
       server: '*'
+    - namespace: 'openclaw'
+      name: '*'
+      server: '*'
+    - namespace: 'tailscale'
+      name: '*'
+      server: '*'
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/kubernetes/deploy/admin/openclaw-operator-system/openclaw-backup/clusters/bastion/external-secret-s3-backup.yaml
+++ b/kubernetes/deploy/admin/openclaw-operator-system/openclaw-backup/clusters/bastion/external-secret-s3-backup.yaml
@@ -1,0 +1,45 @@
+# S3/R2 credentials for the openclaw-operator's scheduled backup flow.
+# The operator reads this Secret from its own namespace
+# (OperatorNamespace = openclaw-operator-system) and mirrors credentials
+# into the backup Job pod only — never onto the gateway StatefulSet.
+# See upstream internal/controller/s3.go for the key contract.
+#
+# REQUIRED secret keys (operator-expected, not negotiable):
+#   - S3_BUCKET
+#   - S3_ENDPOINT
+#   - S3_ACCESS_KEY_ID
+#   - S3_SECRET_ACCESS_KEY
+#
+# The 1Password item stores these under R2_* field names (historical
+# consistency with VolSync's restic backups). The ExternalSecret remaps
+# R2_* remote → S3_* local.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: s3-backup-credentials
+  namespace: openclaw-operator-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: s3-backup-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: S3_BUCKET
+      remoteRef:
+        key: openclaw-backup
+        property: R2_BUCKET
+    - secretKey: S3_ENDPOINT
+      remoteRef:
+        key: openclaw-backup
+        property: R2_ENDPOINT
+    - secretKey: S3_ACCESS_KEY_ID
+      remoteRef:
+        key: openclaw-backup
+        property: R2_ACCESS_KEY_ID
+    - secretKey: S3_SECRET_ACCESS_KEY
+      remoteRef:
+        key: openclaw-backup
+        property: R2_SECRET_ACCESS_KEY

--- a/kubernetes/deploy/admin/openclaw-operator-system/openclaw-backup/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/admin/openclaw-operator-system/openclaw-backup/clusters/bastion/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace is set by the ApplicationSet kustomize.namespace transformer
+# (path segment: "openclaw-operator-system"). This overlay is separate from
+# the main openclaw overlay because the openclaw-operator reads the S3
+# backup credentials Secret from its own namespace (see upstream
+# internal/controller/s3.go: getS3Credentials reads from r.OperatorNamespace).
+# Keeping the Secret in the operator namespace and out of the gateway's
+# namespace is a deliberate blast-radius boundary: the gateway pod's agents
+# cannot reach R2 credentials even indirectly.
+
+resources:
+  - external-secret-s3-backup.yaml

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
@@ -1,0 +1,59 @@
+# OpenClaw gateway configuration. Referenced by the OpenClawInstance via
+# spec.config.configMapRef. The operator loads this as the base config on
+# every reconcile and, when mergeMode=merge, deep-merges it with any runtime
+# state already in the PVC — Git is the base, PVC is the authority for
+# runtime deltas (paired devices, onboarded LLM providers, etc.).
+#
+# The operator's enrichment pipeline (see openclaw-operator
+# internal/resources/configmap.go: BuildConfigMapFromBytes) automatically
+# injects the following at reconcile time — do NOT duplicate them here:
+#   - gateway.auth (mode=token plus the auto-mounted token)
+#   - gateway.trustedProxies (merges 127.0.0.0/8 with anything user-set)
+#   - gateway.controlUi.allowedOrigins (from localhost + ingress hosts +
+#     spec.gateway.controlUiOrigins)
+#   - gateway.bind (loopback; the nginx proxy sidecar handles external)
+#   - gateway.tailscale (injected only when spec.tailscale.enabled — left
+#     off here since exposure is via the tailscale-operator ProxyGroup)
+#   - browser settings (when spec.chromium.enabled)
+#   - OpenTelemetry metrics
+#   - skill packs
+#
+# Source: hand-authored baseline (rainbowtank's live config could not be
+# dumped — sshd is not listening on that host and Tailscale SSH returns
+# 502). Audit fixes from 2026-04-16 Lab Notebook are applied below.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+  namespace: openclaw
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "auth": {
+          "rateLimit": {
+            "maxAttempts": 10,
+            "windowMs": 60000,
+            "lockoutMs": 300000
+          }
+        }
+      },
+      "channels": {
+        "telegram": {
+          "enabled": true,
+          "groupAllowFrom": []
+        }
+      },
+      "agents": {
+        "defaults": {
+          "model": {
+            "primary": "openai/codex-gpt-5-mini",
+            "fallback": "openai/codex-gpt-4.1-mini"
+          },
+          "sandbox": true
+        }
+      },
+      "skills": {
+        "prelude": []
+      }
+    }

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-api-keys.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-api-keys.yaml
@@ -1,0 +1,24 @@
+# Gateway-visible credentials. These are injected into the OpenClaw container
+# as environment variables via spec.envFrom on the OpenClawInstance. Agents
+# running inside the gateway pod can read these values — keep this set
+# MINIMAL and NEVER add R2/S3 or Tailscale credentials here (see
+# external-secret-s3-backup.yaml in the openclaw-backup overlay for the
+# blast-radius-isolated operator-only set).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-api-keys
+  namespace: openclaw
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: openclaw-api-keys
+    creationPolicy: Owner
+  data:
+    - secretKey: TELEGRAM_BOT_TOKEN
+      remoteRef:
+        key: openclaw-gw
+        property: TELEGRAM_BOT_TOKEN

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-gateway-token.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-gateway-token.yaml
@@ -1,0 +1,26 @@
+# Gateway authentication token Secret. The operator reads this via
+# spec.gateway.existingSecret and auto-injects its value as the
+# OPENCLAW_GATEWAY_TOKEN environment variable on the gateway container
+# (see operator internal/resources/statefulset.go). The Secret MUST have a
+# data key named "token".
+#
+# The 1Password field is named GATEWAY_AUTH_SECRET for legacy reasons; the
+# ExternalSecret maps it to the operator-expected key "token".
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw-gw-gateway-token
+  namespace: openclaw
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: openclaw-gw-gateway-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: openclaw-gw
+        property: GATEWAY_AUTH_SECRET

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -1,0 +1,85 @@
+# OpenClawInstance: the single gateway pod for bastion. Fresh start (not a
+# migration from rainbowtank), so no spec.restoreFrom. Backup is enabled;
+# operator reads S3 credentials from the openclaw-backup overlay's
+# ExternalSecret in openclaw-operator-system.
+apiVersion: openclaw.rocks/v1alpha1
+kind: OpenClawInstance
+metadata:
+  name: openclaw-gw
+  namespace: openclaw
+spec:
+  # Image tag omitted — operator/chart defaults pin appVersion.
+
+  # Gateway-visible env (Telegram token only; no R2/Tailscale).
+  envFrom:
+    - secretRef:
+        name: openclaw-api-keys
+
+  # Base config checked into Git. mergeMode=merge preserves runtime state in
+  # the PVC (paired devices, onboarded LLM providers) across reconciles.
+  config:
+    configMapRef:
+      name: openclaw-config
+      key: openclaw.json
+    format: json
+    mergeMode: merge
+
+  # Gateway reverse-proxy sidecar and token auth. The operator creates the
+  # environment variable OPENCLAW_GATEWAY_TOKEN from this Secret's "token"
+  # key. The Secret itself is produced by external-secret-gateway-token.yaml.
+  gateway:
+    enabled: true
+    existingSecret: openclaw-gw-gateway-token
+    controlUiOrigins:
+      - https://openclaw-gw.tailnet-4d89.ts.net
+
+  # Tailscale integration DISABLED: exposure is handled by the
+  # tailscale-operator-managed ProxyGroup in the openclaw-gw-proxygroup
+  # overlay (the tsnet mode baked into OpenClaw itself is redundant here).
+  tailscale:
+    enabled: false
+
+  # Persistent state: agent workspaces, LLM provider auth profiles (Codex
+  # OAuth tokens land here after one-time onboarding), channel connector
+  # state. ZFS-over-iSCSI via democratic-csi is the cluster's only durable
+  # storage class. orphan=true keeps the PVC around if the instance is
+  # deleted.
+  storage:
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: zfs-nvme
+      accessModes:
+        - ReadWriteOnce
+      orphan: true
+
+  # Kubernetes Service shape. Type ClusterIP — the external exposure is the
+  # operator-managed tailscale Service/ProxyGroup, which selects on pod
+  # labels.
+  networking:
+    service:
+      type: ClusterIP
+
+  # Scheduled backup to S3/R2. Operator mounts the s3-backup-credentials
+  # Secret from OperatorNamespace only on Job/CronJob pods — gateway pod
+  # cannot read R2 creds even indirectly.
+  backup:
+    schedule: "0 3 * * *"
+    retentionDays: 14
+    historyLimit: 3
+    failedHistoryLimit: 3
+    timeout: 30m
+
+  # Agents may author their own OpenClawSelfConfig CRs (see selfconfig.yaml)
+  # for narrow self-modifications. Operator enforces schema; human review
+  # gates any merges into this Git overlay.
+  selfConfigure:
+    enabled: true
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace is set by the ApplicationSet kustomize.namespace transformer at
+# deploy time (derived from the overlay path segment: "openclaw"). Do not
+# set a local namespace transformer here.
+
+resources:
+  - external-secret-api-keys.yaml
+  - external-secret-gateway-token.yaml
+  - configmap.yaml
+  - instance.yaml
+  - selfconfig.yaml
+  - service.yaml

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/selfconfig.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/selfconfig.yaml
@@ -1,0 +1,19 @@
+# Empty OpenClawSelfConfig scaffold — exists to be the sole CR the admin
+# agent may edit via PR. Adding a field here produces a rendered patch; the
+# operator applies it on top of the instance's base spec. The Git PR review
+# flow is the enforcement boundary — the CRD itself is permissive on what
+# can be requested.
+apiVersion: openclaw.rocks/v1alpha1
+kind: OpenClawSelfConfig
+metadata:
+  name: openclaw-gw-admin
+  namespace: openclaw
+spec:
+  instanceRef: openclaw-gw
+  addEnvVars: []
+  removeEnvVars: []
+  addSkills: []
+  removeSkills: []
+  addWorkspaceFiles: {}
+  removeWorkspaceFiles: []
+  configPatch: {}

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/service.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/service.yaml
@@ -1,0 +1,37 @@
+# Tailscale-exposed LoadBalancer Service. The tailscale-operator watches for
+# Services with loadBalancerClass=tailscale and a tailscale.com/proxy-group
+# annotation, then advertises the Service on the tailnet via the
+# ProxyGroup's nodes (see proxygroup.yaml in the openclaw-gw-proxygroup
+# overlay). The tailscale.com/hostname annotation overrides the default
+# tailnet DNS name (which would otherwise be
+# <service-name>-<namespace>), producing the clean
+# openclaw-gw.<tailnet>.ts.net name.
+#
+# Named openclaw-gw-tailscale to avoid colliding with the ClusterIP Service
+# the openclaw-operator creates with name = instance name ("openclaw-gw").
+#
+# Selector matches the StatefulSet labels produced by the openclaw-operator
+# (see upstream internal/resources/common.go: SelectorLabels).
+#
+# targetPort 18790 is the gateway proxy sidecar's listen port (nginx), not
+# the gateway's loopback-bound 18789 — the sidecar handles external access
+# when spec.gateway.enabled=true.
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-gw-tailscale
+  namespace: openclaw
+  annotations:
+    tailscale.com/proxy-group: openclaw-gw
+    tailscale.com/hostname: openclaw-gw
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/instance: openclaw-gw
+  ports:
+    - name: https
+      port: 443
+      targetPort: 18790
+      protocol: TCP

--- a/kubernetes/deploy/system/tailscale/openclaw-gw-proxygroup/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/system/tailscale/openclaw-gw-proxygroup/clusters/bastion/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace is set by the ApplicationSet kustomize.namespace transformer
+# (path segment: "tailscale"). The ProxyGroup must live in the same
+# namespace as the tailscale-operator install (see
+# kubernetes/deploy/system/tailscale/tailscale-operator/). This overlay is
+# carved out of the main openclaw overlay because the ApplicationSet
+# enforces a single namespace per overlay and ProxyGroup is a
+# cluster-scoped-but-namespaced CR watched only by the tailscale-operator.
+
+resources:
+  - proxygroup.yaml

--- a/kubernetes/deploy/system/tailscale/openclaw-gw-proxygroup/clusters/bastion/proxygroup.yaml
+++ b/kubernetes/deploy/system/tailscale/openclaw-gw-proxygroup/clusters/bastion/proxygroup.yaml
@@ -1,0 +1,25 @@
+# ProxyGroup: the set of tailnet nodes the tailscale-operator manages to
+# advertise the Tailscale Service svc:openclaw-gw. Nodes run the Tailscale
+# containerboot image and use the operator's OAuth client (configured in
+# the tailscale-operator install overlay) to authenticate — no
+# per-ProxyGroup auth key needed.
+#
+# replicas: 1 because the underlying K8s cluster is a single Talos node;
+# HA isn't possible until more nodes come online. type: ingress pairs with
+# the openclaw-gw-tailscale Service (loadBalancerClass=tailscale +
+# tailscale.com/proxy-group annotation) in the openclaw namespace.
+#
+# tag:openclaw-gw is owned by tag:k8s-operator in the tailnet ACL
+# (jtcressy-home/tailnet-policy PR #2, merged & applied). ACL also
+# auto-approves svc:openclaw-gw for any node bearing this tag.
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyGroup
+metadata:
+  name: openclaw-gw
+  namespace: tailscale
+spec:
+  type: ingress
+  replicas: 1
+  hostnamePrefix: openclaw-gw-k8s
+  tags:
+    - tag:openclaw-gw


### PR DESCRIPTION
## Summary

Stands up the first Git-declarative OpenClaw gateway (`openclaw-gw`) on the `bastion` cluster, implementing `/Documents/Personal/openclaw/tasks/instance-deploy.md` Phase 1. Depends on #707 (operator install) — merged — and `jtcressy-home/tailnet-policy#2` (tag/auto-approver) — merged + applied.

Phase 2 (post-merge verification + Codex OAuth onboarding) is handled by a separately dispatched sub-agent after this PR merges.

## What changed

### New overlays (three — not the single overlay the plan called for; see Design notes below)

- `kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/` — `openclaw` namespace
  - `OpenClawInstance/openclaw-gw` — the single gateway pod spec. 500m/1Gi req, 2/2Gi lim; 10 Gi PVC on `zfs-nvme` with `orphan: true`; Codex OAuth onboarding happens post-deploy via `kubectl exec` (no static provider credentials).
  - `ConfigMap/openclaw-config` — hand-authored base config (the rainbowtank dump was unreachable — sshd is not listening and Tailscale SSH returns 502). Audit fixes from 2026-04-16 Lab Notebook are baked in (`gateway.auth.rateLimit`, `channels.telegram.groupAllowFrom: []`). The operator's enrichment pipeline auto-injects `gateway.trustedProxies`, `gateway.controlUi.allowedOrigins`, `gateway.bind`, and gateway auth at reconcile time — these are deliberately omitted from the base config.
  - `ExternalSecret/openclaw-api-keys` — Telegram token only, wired into `spec.envFrom`.
  - `ExternalSecret/openclaw-gw-gateway-token` — produces a Secret with key `token` (the operator-expected shape; see upstream `internal/resources/common.go: GatewayTokenSecretKey`). Referenced via `spec.gateway.existingSecret`, operator auto-injects `OPENCLAW_GATEWAY_TOKEN` env var.
  - `OpenClawSelfConfig/openclaw-gw-admin` — empty scaffold; the sole CR an admin agent may PR against.
  - `Service/openclaw-gw-tailscale` — `LoadBalancer` + `loadBalancerClass: tailscale` + `tailscale.com/proxy-group: openclaw-gw` + `tailscale.com/hostname: openclaw-gw`. Named `-tailscale` to avoid colliding with the ClusterIP Service the operator creates with name = instance name. `targetPort: 18790` is the gateway-proxy sidecar's nginx listener.
- `kubernetes/deploy/admin/openclaw-operator-system/openclaw-backup/clusters/bastion/` — `openclaw-operator-system` namespace
  - `ExternalSecret/s3-backup-credentials` — operator-only R2 credentials. **Secret keys remapped `R2_* -> S3_*`** to match the operator's expected schema (see upstream `internal/controller/s3.go: getS3Credentials` — requires `S3_BUCKET`, `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`). Gateway pod cannot read these even indirectly.
- `kubernetes/deploy/system/tailscale/openclaw-gw-proxygroup/clusters/bastion/` — `tailscale` namespace
  - `ProxyGroup/openclaw-gw` — `type: ingress`, `replicas: 1`, `tags: [tag:openclaw-gw]`. Operator's OAuth client handles node auth; no per-ProxyGroup auth key.

### AppProject destination updates

`kubernetes/argocd/projects/admin.yaml` — added `openclaw` and `tailscale` namespace destinations so the openclaw and ProxyGroup overlays are permitted under the `admin` project.

## Design notes / schema drift from the written plan

1. **Cross-namespace overlay split.** The plan called for a single overlay spanning three namespaces (`openclaw`, `openclaw-operator-system`, `tailscale`) with each resource setting `.metadata.namespace` explicitly and no top-level `namespace:` transformer in the kustomization. That isn't realizable under this repo's ApplicationSet design: the appset template injects `kustomize.namespace` at deploy time (derived from the overlay path segment), which forcibly rewrites every resource's namespace. Verified against live state — the `tailscale-operator` overlay's ExternalSecret is declared with `namespace: tailscale-operator` locally but lands in `tailscale` in the cluster due to this transformer. Split into three overlays, one per namespace, and added project destinations accordingly.
2. **Gateway auth secret shape.** Plan specified `OPENCLAW_GATEWAY_AUTH_SECRET` fed via `envFrom`. Actual operator contract: Secret with key `token`, referenced via `spec.gateway.existingSecret`, operator injects env var `OPENCLAW_GATEWAY_TOKEN` automatically. The 1Password item field `GATEWAY_AUTH_SECRET` is remapped to the expected `token` key.
3. **Backup secret keys.** Plan specified `R2_*`. Operator expects `S3_*` (see source reference above). ExternalSecret handles the remap.
4. **OpenClawInstance CRD field names (verified via `kubectl explain`):** `storage.persistence.storageClass` (not `storageClassName`); no top-level `replicaCount` (StatefulSet is always 1 per instance); service config lives under `networking.service` (not top-level `service`); `selfConfigure` has only `enabled` + `allowedActions` — the allowlists the plan described (`allowedEnvVars`, `allowedSkillSources`, `allowedConfigPatchPaths`) are not fields on the CRD and are enforced via Git PR review instead.
5. **Tailscale integration.** Plan said `gateway.tailscale.mode: off` in the config JSON. Actual lever is `spec.tailscale.enabled: false` on the CR — the in-gateway tsnet is disabled entirely because exposure is via the tailscale-operator-managed ProxyGroup + Service.
6. **Tailnet DNS name.** Default tailscale-operator naming is `<service-name>-<namespace>` (i.e. `openclaw-gw-tailscale-openclaw.<tailnet>.ts.net`). `tailscale.com/hostname: openclaw-gw` annotation overrides that to produce the clean `openclaw-gw.<tailnet>.ts.net` target.
7. **Config seed source.** Hand-authored baseline, not a port of rainbowtank's live config — sshd is not listening on rainbowtank and Tailscale SSH returns 502. Loses any rainbowtank-specific tuning that hasn't been re-applied here. If the live config is dumped to `/tmp/claude/openclaw-rainbowtank-config.json` before Phase 2 sync, a follow-up PR can reconcile deltas without touching ingress / ACL wiring.

## Pre-merge PM action required

Delete the pre-existing manually-configured `svc:openclaw-gw` in the Tailscale admin console. The operator cannot claim a pre-existing Service; it only creates fresh ones.

## Verification (to be executed by Phase 2 sub-agent after merge + ArgoCD sync)

- [ ] `kubectl -n openclaw get externalsecret openclaw-api-keys -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` -> `True`
- [ ] `kubectl -n openclaw get externalsecret openclaw-gw-gateway-token -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` -> `True`
- [ ] `kubectl -n openclaw-operator-system get externalsecret s3-backup-credentials -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` -> `True`; Secret has exactly `S3_BUCKET`, `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`.
- [ ] `kubectl -n openclaw get secret openclaw-api-keys -o jsonpath='{.data}' | jq 'keys'` does NOT contain any R2 / S3 / Tailscale key (blast-radius check).
- [ ] `kubectl -n openclaw get openclawinstance openclaw-gw -o jsonpath='{.status.phase}'` -> `Running`.
- [ ] `kubectl -n openclaw get pvc` — bound on `zfs-nvme`, 10 Gi.
- [ ] `kubectl -n tailscale get proxygroup openclaw-gw -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` -> `True`.
- [ ] `kubectl -n openclaw get service openclaw-gw-tailscale` — `LoadBalancer` with Tailscale-assigned hostname.
- [ ] `tailscale status` from another tailnet device shows `openclaw-gw-k8s-0` tagged `tag:openclaw-gw`; `svc:openclaw-gw` resolves.
- [ ] Browse `https://openclaw-gw.<tailnet>.ts.net` — Control UI loads.
- [ ] Pair iPhone + laptop (fresh trust chain; this is a new instance).
- [ ] `kubectl -n openclaw exec openclaw-gw-0 -- openclaw security audit --deep` -> no CRITICAL, no WARN.
- [ ] Send test message to Telegram bot — bot replies.
- [ ] `kubectl -n openclaw get openclawselfconfig openclaw-gw-admin -o jsonpath='{.status.phase}'` -> `Applied`.

## Post-merge onboarding (one-time, manual)

After Phase 2 verification passes, run the Codex OAuth flow once:

```sh
kubectl -n openclaw exec -it openclaw-gw-0 -- openclaw onboard --openai-codex
```

Tokens land in the PVC under OpenClaw's per-agent auth-profiles path and auto-refresh thereafter. If the PVC is ever lost, repeat once.

## Test plan

- [ ] `task apps:overlays:render project=admin namespace=openclaw app=openclaw cluster=bastion` — clean render, six resources, all in `openclaw` namespace.
- [ ] `task apps:overlays:render project=admin namespace=openclaw-operator-system app=openclaw-backup cluster=bastion` — clean render, ExternalSecret in `openclaw-operator-system`.
- [ ] `task apps:overlays:render project=system namespace=tailscale app=openclaw-gw-proxygroup cluster=bastion` — clean render, ProxyGroup in `tailscale`.
- [ ] `kubectl apply --dry-run=server` on the three rendered outputs — no schema errors (namespace-not-found for the `openclaw` namespace is expected pre-merge; it's created by ArgoCD on sync).
