### PR TITLE
fix(openclaw): allow config/skills/files selfConfigure actions

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -75,6 +75,10 @@ spec:
   # gates any merges into this Git overlay.
   selfConfigure:
     enabled: true
+    allowedActions:
+      - config
+      - skills
+      - files
 
   resources:
     requests:


### PR DESCRIPTION
## Root cause

The `OpenClawSelfConfig/openclaw-gw-admin` CR deployed alongside the Instance was stuck in phase `Denied` with message `denied actions: [config]`. The scaffold includes an empty `configPatch: {}` which the operator still counts as an attempted `config` action. The `OpenClawInstance.spec.selfConfigure.allowedActions` list was unset, so the operator denied everything, including the empty-map no-op `config`.

## Fix

Add `allowedActions` under `spec.selfConfigure` in the bastion OpenClawInstance overlay:

```yaml
spec:
  selfConfigure:
    enabled: true
    allowedActions:
      - config
      - skills
      - files
```

## Policy rationale

Per the parent pivot plan's admin-agent workflow, the agent's primary value is editing `configPatch` (to add skills, adjust channels, tune agent defaults within allowed paths). Denying `config` entirely defeats the purpose.

- `config` — permits `configPatch`, the agent's main self-modification surface
- `skills` — permits `addSkills` / `removeSkills`
- `files` — permits `addWorkspaceFiles` / `removeWorkspaceFiles`
- NOT included: `env` — keeping the env-var surface human-only for now

If the operator later exposes finer-grained path allowlists inside `config` (e.g. `allowedConfigPaths`), those can be layered in a follow-up.

## Verification (post-merge)

1. ArgoCD syncs the `openclaw` app.
2. `kubectl -n openclaw get openclawinstance openclaw-gw -o jsonpath='{.spec.selfConfigure.allowedActions}'` includes `config`, `skills`, `files`.
3. `kubectl -n openclaw get openclawselfconfig openclaw-gw-admin -o jsonpath='{.status.phase}'` flips from `Denied` to `Applied` (operator re-reconciles on Instance spec change).
4. `kubectl -n openclaw get openclawselfconfig openclaw-gw-admin -o jsonpath='{.status.message}'` no longer contains `denied actions`.

## Scope

- One file, one field added. No topology/operator/Tailscale changes.
- Task plan: `openclaw/tasks/openclaw-selfconfig-allow-config.md` (approved).
