### PR TITLE
fix(openclaw): lower OpenClawInstance memory request to 512Mi

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -79,7 +79,7 @@ spec:
   resources:
     requests:
       cpu: 500m
-      memory: 1Gi
+      memory: 512Mi
     limits:
       cpu: "2"
       memory: 2Gi


### PR DESCRIPTION
## Root cause

`openclaw-gw-0` pod is stuck `Pending` with:

```
0/1 nodes are available: 1 Insufficient memory. no new claims to deallocate
```

The single node (`talos-master-0`) is at **97% memory-requested** (32.2 GiB / 33 GiB) while only **47% actually used** (14.98 GiB). The scheduler honors `requests`, not live usage, so the pod cannot fit even though the node has plenty of free RAM.

OpenClawInstance currently asks for:

- main container: `500m` CPU / `1Gi` memory request, `2` CPU / `2Gi` memory limit
- init container: 16 MiB memory
- otel sidecar: 32 MiB memory

Total pod request: ~1.05 GiB. Node has ~0.8 GiB free by requests — shortfall ~250 MiB.

## Change

Drop the main container memory **request** from `1Gi` to `512Mi`. The **limit stays at `2Gi`** so the pod can still burst if real usage demands it.

```diff
   resources:
     requests:
       cpu: 500m
-      memory: 1Gi
+      memory: 512Mi
     limits:
       cpu: "2"
       memory: 2Gi
```

One-line edit in `kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml`.

## Expected outcome

After ArgoCD syncs:

1. `OpenClawInstance openclaw-gw` re-renders with `requests.memory: 512Mi`.
2. StatefulSet rolls, the new `openclaw-gw-0` pod fits within node requests and flips `Pending` → `Running`.
3. Actual memory usage remains well under the unchanged `2Gi` limit under typical load.

## Out of scope

Cluster-wide over-request hygiene (node at 97% requested vs 47% used implies ~17 GiB of stale requests elsewhere) is tracked separately if it becomes chronic.
