### PR TITLE
fix(tailscale): migrate default ProxyClass to devic.es/tun

### DIFF
--- a/kubernetes/deploy/system/tailscale/tailscale-operator/clusters/bastion/proxyclass.yaml
+++ b/kubernetes/deploy/system/tailscale/tailscale-operator/clusters/bastion/proxyclass.yaml
@@ -10,4 +10,4 @@ spec:
       tailscaleContainer:
         resources:
           limits:
-            squat.ai/tun: "1"
+            devic.es/tun: "1"


### PR DESCRIPTION
## Root cause

Upstream `generic-device-plugin` renamed its K8s resource prefix `squat.ai/*` → `devic.es/*` in digest `d9e098e` (PR #702, 2026-04-15). Node now advertises `devic.es/tun: 1k`, `squat.ai/tun: 0`.

The `default` ProxyClass hardcodes `squat.ai/tun: "1"` as the resource limit for every tailscale-operator-managed proxy pod. All 20 existing `ts-*` pods are grandfathered (allocated before the plugin bump). New proxies (e.g. the pending `openclaw-gw` ProxyGroup pod) cannot schedule with `Insufficient squat.ai/tun`.

## Fix

Single field change in `kubernetes/deploy/system/tailscale/tailscale-operator/clusters/bastion/proxyclass.yaml`:

```diff
-            squat.ai/tun: "1"
+            devic.es/tun: "1"
```

## Blast radius

**Rolling restart of all ~20 tailscale-operator proxy pods** in the `tailscale` namespace when the ProxyClass change propagates. Every tailnet-exposed service gets a brief outage window (seconds to ~1 minute per pod):

argocd, grafana, hubble-ui, searxng, n8n, n8n-mcp, metamcp, overseerr, navidrome, lidarr, radarr, sonarr, prowlarr, sabnzbd, tautulli, teslamate, victoria-logs, vmsingle, tsidp, golink.

Net gain: `openclaw-gw` ProxyGroup pod finally schedules, `svc:openclaw-gw` resolves on the tailnet.

## Verification (post-merge)

1. `kubectl get proxyclass default -o jsonpath='{.spec.statefulSet.pod.tailscaleContainer.resources.limits}'` shows `devic.es/tun: 1`
2. All `ts-*` pods roll to Ready
3. `kubectl describe node | grep tun` — `devic.es/tun: 20+ allocated`, `squat.ai/tun: 0 allocated`
4. `kubectl -n tailscale get pods | grep openclaw-gw` → Running

## History note

Original branch `fix/proxyclass-devic-es-tun` got polluted by a concurrent subagent's commit. This branch (`…-v2`) is a clean cherry-pick of the intended single-line change off current `main`. The original polluted branch has no open PR and can be deleted.

## Scope

- Task plan: `openclaw/tasks/migrate-device-plugin-resource-keys.md` (approved).
- Supersedes the deleted `revert-generic-device-plugin.md` — user chose forward migration over revert.
