### PR TITLE
fix(openclaw): correct selfConfigure allowedActions enum (files → workspaceFiles)

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -78,7 +78,7 @@ spec:
     allowedActions:
       - config
       - skills
-      - files
+      - workspaceFiles
 
   resources:
     requests:


### PR DESCRIPTION
## Summary

One-line fix for `kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml`:

```diff
     allowedActions:
       - config
       - skills
-      - files
+      - workspaceFiles
```

The `openclawinstances.openclaw.rocks` CRD restricts `spec.selfConfigure.allowedActions` to the enum `{skills, config, workspaceFiles, envVars}`. Prior PR #709 shipped the invalid value `files`, which the API server rejects on every patch. As a result, the `openclaw-bastion` ArgoCD app has been stuck `OutOfSync` in a retry loop, and the memory-request reduction merged in PR #710 (1Gi -> 512Mi) has been unable to land on the cluster.

This single merge unblocks sync so both:
1. the corrected `allowedActions` enum, and
2. the already-merged 512Mi memory request from PR #710

apply in the same ArgoCD reconcile.

## Context

- Cause: #709
- Also blocked by #709: #710 (already merged, waiting on sync)
- `envVars` intentionally omitted -- env-var surface stays human-only for now.

## Verification (post-merge)

1. `kubectl -n openclaw get openclawinstance openclaw-gw -o jsonpath='{.spec.selfConfigure.allowedActions}'` contains `config`, `skills`, `workspaceFiles` (and NOT `files`).
2. `kubectl -n openclaw get openclawinstance openclaw-gw -o jsonpath='{.spec.resources.requests.memory}'` = `512Mi` (from #710, previously blocked from applying).
3. `kubectl -n openclaw get openclawselfconfig openclaw-gw-admin -o jsonpath='{.status.phase}'` flips from `Denied` to `Applied` within ~1 min of sync.
4. `.status.message` no longer contains `denied actions`.
5. ArgoCD app `openclaw-bastion` returns to Healthy/Synced.
6. `kubectl -n openclaw get pod openclaw-gw-0 -o jsonpath='{.status.phase}'` -- scheduler re-evaluates with the new 512 MiB request.

## Rollback

Revert this PR. Sync stays broken at the prior state; pod is already Pending, nothing worsens.
