### PR TITLE
feat(openclaw): install qmd memory backend via init container

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
@@ -56,5 +56,8 @@ data:
             "primary": "openai-codex/gpt-5.4"
           }
         }
+      },
+      "memory": {
+        "backend": "qmd"
       }
     }

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -15,6 +15,59 @@ spec:
     - secretRef:
         name: openclaw-api-keys
 
+  # PATH override so the gateway (a Node process) and its spawned children
+  # can resolve qmd, uv, and anything else installed by init containers into
+  # the PVC at /home/openclaw/.local/bin. The default container PATH does
+  # not include that directory, and Node's spawn() inherits the parent
+  # process PATH verbatim.
+  env:
+    - name: PATH
+      value: /home/openclaw/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+  # Install @tobilu/qmd into the PVC so the gateway's qmd memory backend
+  # has its binary available. Mirrors the operator's own init-uv pattern:
+  # idempotent, writes into /data/.local which is the same path the main
+  # container sees as /home/openclaw/.local. qmd downloads ~2GB of GGUF
+  # models to ~/.cache/qmd on first use — also on the PVC, so models
+  # persist across pod restarts.
+  #
+  # node:24-bookworm-slim has npm; qmd's native deps (better-sqlite3,
+  # node-llama-cpp, sqlite-vec) ship prebuilt binaries for linux/x64 so no
+  # build toolchain is required.
+  initContainers:
+    - name: init-qmd
+      image: node:24-bookworm-slim
+      command:
+        - sh
+        - -c
+        - |
+          set -e
+          if [ -x /data/.local/bin/qmd ]; then
+            echo "qmd already installed: $(/data/.local/bin/qmd --version 2>/dev/null || echo unknown)"
+            exit 0
+          fi
+          export HOME=/tmp
+          export NPM_CONFIG_PREFIX=/data/.local
+          export NPM_CONFIG_CACHE=/data/.cache/npm
+          npm install -g @tobilu/qmd
+          /data/.local/bin/qmd --version
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - mountPath: /data
+          name: data
+        - mountPath: /tmp
+          name: tmp
+
   # Base config checked into Git. mergeMode=replace makes the ConfigMap the
   # sole source of truth for openclaw.json on every reconcile, evicting any
   # residual keys left by prior bad-config merges. Runtime state (paired


### PR DESCRIPTION
## Summary
- Install @tobilu/qmd into the gateway PVC via an `init-qmd` init container (same pattern as operator-managed `init-uv`).
- Prepend `/home/openclaw/.local/bin` to the container `PATH` so the Node gateway and its spawned subprocesses can resolve `qmd` (container default `PATH` does not include `$HOME/.local/bin`, and `child_process.spawn()` inherits parent `PATH` verbatim).
- Set `memory.backend: "qmd"` in `openclaw-config` to activate the qmd backend. All other `memory.qmd.*` keys stay at their defaults for now.

## Why
Previous attempt to use the built-in `basic-memory` backend with the Ollama backend ran into sqlite issues. QMD (a local BM25 + vector + re-ranking search engine) is the backend OpenClaw is designed around — its own docs mount it as a sidecar per-agent. QMD ships as an npm package with prebuilt native binaries for linux/x64 (`better-sqlite3`, `node-llama-cpp`, `sqlite-vec`), so no build toolchain is required in the init container.

QMD downloads ~2 GB of GGUF models to `~/.cache/qmd` on first use. That path is on the PVC subPath `.cache`, so models persist across pod restarts. Current PVC utilization is 3% of 10 Gi — plenty of room.

## Test plan
- [ ] ArgoCD syncs `openclaw-bastion`, operator restarts the gateway pod.
- [ ] `kubectl -n openclaw logs openclaw-gw-0 -c init-qmd` shows `qmd <version>` at the end (or the early-exit idempotency line on subsequent reconciles).
- [ ] `kubectl -n openclaw exec openclaw-gw-0 -c openclaw -- sh -c "which qmd; qmd --version"` resolves to `/home/openclaw/.local/bin/qmd`.
- [ ] Gateway starts with memory backend = qmd (no sqlite errors in logs; first model download visible in `/home/openclaw/.cache/qmd/models/`).
- [ ] Basic memory ops from the Control UI / CLI work end-to-end.
