### PR TITLE
revert(openclaw): drop qmd, use built-in memory with rainbowtank Ollama

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
@@ -59,7 +59,7 @@ data:
             "provider": "ollama",
             "model": "qwen3-embedding:4b",
             "remote": {
-              "baseUrl": "http://100.120.142.7:11434"
+              "baseUrl": "http://rainbowtank.tailnet-4d89.ts.net:11434"
             }
           }
         }

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
@@ -54,10 +54,14 @@ data:
           },
           "model": {
             "primary": "openai-codex/gpt-5.4"
+          },
+          "memorySearch": {
+            "provider": "ollama",
+            "model": "qwen3-embedding:4b",
+            "remote": {
+              "baseUrl": "http://100.120.142.7:11434"
+            }
           }
         }
-      },
-      "memory": {
-        "backend": "qmd"
       }
     }

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/instance.yaml
@@ -15,59 +15,6 @@ spec:
     - secretRef:
         name: openclaw-api-keys
 
-  # PATH override so the gateway (a Node process) and its spawned children
-  # can resolve qmd, uv, and anything else installed by init containers into
-  # the PVC at /home/openclaw/.local/bin. The default container PATH does
-  # not include that directory, and Node's spawn() inherits the parent
-  # process PATH verbatim.
-  env:
-    - name: PATH
-      value: /home/openclaw/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-  # Install @tobilu/qmd into the PVC so the gateway's qmd memory backend
-  # has its binary available. Mirrors the operator's own init-uv pattern:
-  # idempotent, writes into /data/.local which is the same path the main
-  # container sees as /home/openclaw/.local. qmd downloads ~2GB of GGUF
-  # models to ~/.cache/qmd on first use — also on the PVC, so models
-  # persist across pod restarts.
-  #
-  # node:24-bookworm-slim has npm; qmd's native deps (better-sqlite3,
-  # node-llama-cpp, sqlite-vec) ship prebuilt binaries for linux/x64 so no
-  # build toolchain is required.
-  initContainers:
-    - name: init-qmd
-      image: node:24-bookworm-slim
-      command:
-        - sh
-        - -c
-        - |
-          set -e
-          if [ -x /data/.local/bin/qmd ]; then
-            echo "qmd already installed: $(/data/.local/bin/qmd --version 2>/dev/null || echo unknown)"
-            exit 0
-          fi
-          export HOME=/tmp
-          export NPM_CONFIG_PREFIX=/data/.local
-          export NPM_CONFIG_CACHE=/data/.cache/npm
-          npm install -g @tobilu/qmd
-          /data/.local/bin/qmd --version
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        seccompProfile:
-          type: RuntimeDefault
-      volumeMounts:
-        - mountPath: /data
-          name: data
-        - mountPath: /tmp
-          name: tmp
-
   # Base config checked into Git. mergeMode=replace makes the ConfigMap the
   # sole source of truth for openclaw.json on every reconcile, evicting any
   # residual keys left by prior bad-config merges. Runtime state (paired


### PR DESCRIPTION
## Summary
Reverts #715. QMD ships no Ollama integration: it embeds/reranks/expands queries with local GGUF models via `node-llama-cpp` and will only accept HuggingFace GGUF overrides via `QMD_EMBED_MODEL` / `QMD_RERANK_MODEL` / `QMD_GENERATE_MODEL`. That defeats the decision to offload inference to rainbowtank (100.120.142.7:11434) and puts CPU/memory pressure back on the resource-constrained gateway pod.

This PR:
- Drops the `init-qmd` init container, `PATH` env override, and `memory.backend: qmd` config added in #715.
- Leaves the built-in memory backend (default when `memory.backend` is unset), which per the OpenClaw docs supports `provider: ollama`.
- Configures `agents.defaults.memorySearch` to use `qwen3-embedding:4b` (already pulled on rainbowtank) via `http://100.120.142.7:11434`.

Residual QMD install on the PVC (`/home/openclaw/.local/bin/qmd`, `node_modules`, a 3 MB qmd sqlite index under `agents/main/qmd/`) is harmless and left in place — nothing will invoke it once the spec no longer asks for it.

## Known blocker (not this PR)
Testing the new config from the gateway pod showed that `rainbowtank:11434/api/embeddings` currently returns:
```
{"error":"error starting runner: fork/exec /var/home/linuxbrew/.linuxbrew/Cellar/ollama/0.20.7/bin/ollama: no such file or directory"}
```
The Ollama HTTP service is running (`/api/tags` succeeds, lists `qwen3-embedding:4b`), but its configured runner path is stale. Fix on the rainbowtank host is a separate task (check the systemd/Quadlet unit for the bad path, reinstall or reconfigure ollama).

Until that is fixed, memory search will fail to embed — but the config is correct and will work the moment rainbowtank is repaired.

## Test plan
- [ ] ArgoCD syncs `openclaw-bastion`; pod restarts.
- [ ] `kubectl -n openclaw get pod openclaw-gw-0 -o jsonpath="{.spec.initContainers[*].name}"` no longer contains `init-qmd`.
- [ ] Gateway logs no longer show `qmd memory startup initialization armed`.
- [ ] `kubectl -n openclaw exec openclaw-gw-0 -c openclaw -- openclaw memory status` shows `Provider: ollama (requested: ollama)` and `Model: qwen3-embedding:4b`.
- [ ] Once rainbowtank Ollama is fixed: `openclaw memory status --deep` probes successfully; `openclaw memory index --force` completes without errors.
