### PR TITLE
feat(openclaw): use openrouter for memory embeddings

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/configmap.yaml
@@ -56,10 +56,10 @@ data:
             "primary": "openai-codex/gpt-5.4"
           },
           "memorySearch": {
-            "provider": "ollama",
-            "model": "qwen3-embedding:4b",
+            "provider": "openai",
+            "model": "openai/text-embedding-3-small",
             "remote": {
-              "baseUrl": "http://rainbowtank.tailnet-4d89.ts.net:11434"
+              "baseUrl": "https://openrouter.ai/api/v1"
             }
           }
         }

--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-api-keys.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/external-secret-api-keys.yaml
@@ -22,3 +22,11 @@ spec:
       remoteRef:
         key: openclaw-gw
         property: TELEGRAM_BOT_TOKEN
+    # OpenRouter key exposed as OPENAI_API_KEY because OpenClaw's memory
+    # provider=openai reads that env var name and we're pointing its baseUrl
+    # at OpenRouter's OpenAI-compatible /v1/embeddings surface. See
+    # configmap.yaml agents.defaults.memorySearch.
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: OpenRouter
+        property: apikey


### PR DESCRIPTION
## Summary
Use OpenRouter as the embeddings provider for OpenClaw memory while local options are unavailable.

- rainbowtank ollama: broken (stale runner path from a Homebrew Cellar upgrade)
- purplebox ollama GPU: blocked on NVIDIA 595.58.03 kernel module loading, which is gated by Secure Boot MOK enrollment — MOK enrollment requires interactive console access (MokManager TUI at boot), so deferred to the next physical/iKVM window
- purplebox ollama CPU: LXC is currently unprivileged with no tailscale, so not reachable from the gateway pod without network rework

OpenRouter fills the gap: OpenAI-compatible `/v1/embeddings` surface, spend limit already in place, reliable.

## Changes

### `external-secret-api-keys.yaml`
Adds `OPENAI_API_KEY` pulled from 1Password item `OpenRouter` field `apikey`. The env var is named `OPENAI_API_KEY` (not `OPENROUTER_API_KEY`) because OpenClaw's `provider: openai` code path reads that specific name — avoids needing a custom adapter. A comment in the file explains.

### `configmap.yaml`
Swaps `agents.defaults.memorySearch` from ollama/qwen3-embedding → openai/text-embedding-3-small via OpenRouter:
```json
"memorySearch": {
  "provider": "openai",
  "model": "openai/text-embedding-3-small",
  "remote": {
    "baseUrl": "https://openrouter.ai/api/v1"
  }
}
```
Model ID uses OpenRouter's provider-prefixed format (`openai/<model>`). `text-embedding-3-small` is 1536-dim, ~$0.02/1M tokens + OpenRouter's small markup.

### NetworkPolicy
No change — cluster default egress already allows TCP/443 to external hosts, so `openrouter.ai:443` is covered. The `netpol-egress-ollama.yaml` rule for rainbowtank stays in place (harmless when unused).

## Test plan
- [ ] ExternalSecret refreshes, `Secret/openclaw-api-keys` gets a new `OPENAI_API_KEY` key populated from 1Password.
- [ ] ArgoCD sync rolls the gateway pod (secret-hash annotation changes → restart).
- [ ] `openclaw memory status` inside the pod shows `Provider: openai (requested: openai)` and `Model: openai/text-embedding-3-small`.
- [ ] `openclaw memory status --deep` passes the embedding provider probe.
- [ ] `openclaw memory index --force` completes without errors; `Batch: failures 0/N` stays at 0.
- [ ] OpenRouter dashboard shows the request traffic.
