### PR TITLE
fix(openclaw): rename Tailscale Ingress to avoid openclaw-operator name collision

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/ingress.yaml
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/ingress.yaml
@@ -13,8 +13,9 @@
 # svc:openclaw-gw via tailnet-policy repo).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
+# Name must not match the OpenClawInstance: reconcileIngress deletes matching Ingresses when ingress.enabled=false.
 metadata:
-  name: openclaw-gw
+  name: openclaw-gw-ts
   namespace: openclaw
   annotations:
     tailscale.com/proxy-group: openclaw-gw


### PR DESCRIPTION
## Summary

- Rename `openclaw/openclaw-gw` Ingress → `openclaw-gw-ts` so the openclaw-operator stops deleting it.
- Tailnet DNS label unchanged: `openclaw-gw.<tailnet>.ts.net`, derived from `tls.hosts[0]`.
- No other config changes.

## Root cause

openclaw-operator v0.28.0 `reconcileIngress` unconditionally deletes any Ingress whose name matches the OpenClawInstance name when `spec.networking.ingress.enabled=false` (which it is here). No ownerRef/label check. See `internal/controller/openclawinstance_controller.go` [v0.28.0 source](https://github.com/openclaw-rocks/openclaw-operator/blob/v0.28.0/internal/controller/openclawinstance_controller.go). Our hand-authored Ingress shared the instance name, so it was being deleted on every reconcile — ArgoCD selfHeal has already recreated it ~860 times over the past ~5 days without ever staying alive long enough for the Tailnet Service `svc:openclaw-gw` to persist.

## Why rename instead of enabling the operator's Ingress

The operator's Ingress builder produces `spec.rules` from its `hosts` field. Tailscale-operator ProxyGroup mode rejects `rules.host` entries — it only accepts `spec.defaultBackend`. Until that's fixed upstream, the only viable shape for ProxyGroup + TLS termination is a hand-authored Ingress. Rename is the minimal change that unblocks it.

## Test plan

- [ ] ArgoCD `openclaw-bastion` reaches Synced/Healthy after this merges, and `autoHealAttemptsCount` stops incrementing
- [ ] `kubectl -n openclaw get ingress openclaw-gw-ts` UID stays stable for >10 min
- [ ] Tailscale-operator logs stop showing the `exposing → Ensuring cleanup` loop every 5 min
- [ ] `svc:openclaw-gw` is resolvable from another tailnet node; `https://openclaw-gw.<tailnet>.ts.net/` returns valid TLS and loads the OpenClaw Control UI

Follow-up noted in Obsidian vault to file an upstream ownerRef/label guard at `openclaw-rocks/openclaw-operator` so the next user does not hit this silently.
