### PR TITLE
Add RustDesk server manifests and kustomize overlay for bastion cluster

### DIFF
--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustdesk
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rustdesk
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rustdesk
+    spec:
+      containers:
+        - name: hbbs
+          image: rustdesk/rustdesk-server:1.1.14
+          imagePullPolicy: IfNotPresent
+          command: ["hbbs", "-r", "127.0.0.1:21117"]
+          envFrom:
+            - secretRef:
+                name: rustdesk-secrets
+          ports:
+            - containerPort: 21115
+              protocol: TCP
+            - containerPort: 21116
+              protocol: TCP
+            - containerPort: 21116
+              protocol: UDP
+            - containerPort: 21118
+              protocol: TCP
+            - containerPort: 21119
+              protocol: TCP
+          volumeMounts:
+            - name: rustdesk-data
+              mountPath: /root
+        - name: hbbr
+          image: rustdesk/rustdesk-server:1.1.14
+          imagePullPolicy: IfNotPresent
+          command: ["hbbr"]
+          envFrom:
+            - secretRef:
+                name: rustdesk-secrets
+          ports:
+            - containerPort: 21117
+              protocol: TCP
+          volumeMounts:
+            - name: rustdesk-data
+              mountPath: /root
+      volumes:
+        - name: rustdesk-data
+          persistentVolumeClaim:
+            claimName: rustdesk-data

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/externalsecret.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rustdesk-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: rustdesk-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: rustdesk-env

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/ingress-web.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/ingress-web.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rustdesk-web
+  annotations:
+    # tailscale.com/funnel: "true"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: rustdesk-hbbs
+      port:
+        number: 21119

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - externalsecret.yaml
+  - pvc.yaml
+  - service-hbbs.yaml
+  - service-hbbr.yaml
+  - ingress-web.yaml

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/pvc.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustdesk-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/service-hbbr.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/service-hbbr.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustdesk-hbbr
+  annotations:
+    tailscale.com/hostname: rustdesk-hbbr
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: rustdesk
+  ports:
+    - name: relay-tcp
+      port: 21117
+      targetPort: 21117
+      protocol: TCP

--- a/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/service-hbbs.yaml
+++ b/kubernetes/deploy/home/rustdesk/rustdesk/clusters/bastion/service-hbbs.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustdesk-hbbs
+  annotations:
+    tailscale.com/hostname: rustdesk-hbbs
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app.kubernetes.io/name: rustdesk
+  ports:
+    - name: nat-test-tcp
+      port: 21115
+      targetPort: 21115
+      protocol: TCP
+    - name: id-tcp
+      port: 21116
+      targetPort: 21116
+      protocol: TCP
+    - name: id-udp
+      port: 21116
+      targetPort: 21116
+      protocol: UDP
+    - name: api-tcp
+      port: 21118
+      targetPort: 21118
+      protocol: TCP
+    - name: webclient-tcp
+      port: 21119
+      targetPort: 21119
+      protocol: TCP


### PR DESCRIPTION
### Motivation
- Provide a deployable RustDesk server stack (hbbs/hbbr) for the `bastion` cluster to terminate relay/ID/web traffic. 
- Use a persistent volume for server state and external secrets for credentials so secrets are not checked into manifests. 
- Expose services via Tailscale-backed LoadBalancer and provide an Ingress for the web client. 

### Description
- Add `deployment.yaml` that runs `rustdesk/rustdesk-server:1.1.14` with two containers (`hbbs` and `hbbr`), mounts a PVC at `/root`, and sources environment from the `rustdesk-secrets` secret. 
- Add `externalsecret.yaml` to pull environment data from a `ClusterSecretStore` named `onepassword` into a `rustdesk-secrets` Kubernetes Secret. 
- Add `service-hbbs.yaml` and `service-hbbr.yaml` as `LoadBalancer` services with `tailscale` annotations and ports for the RustDesk protocols. 
- Add `pvc.yaml` for a 5Gi `rustdesk-data` PersistentVolumeClaim, `ingress-web.yaml` to route the web client to the hbbs service, and a `kustomization.yaml` that assembles these resources. 

### Testing
- Ran `kustomize build` against the new overlay to validate manifest rendering and it completed successfully. 
- No unit or CI tests were added for these Kubernetes manifests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f402109c8333a7457046c9250cf8)