### PR TITLE
[codex] Disable ApplicationSet git submodules

### DIFF
--- a/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-cmd-params-cm.yaml
+++ b/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-cmd-params-cm.yaml
@@ -10,5 +10,6 @@ data:
   # the public GitOps tree, so do not initialize submodules during target-state
   # generation.
   reposerver.enable.git.submodule: "false"
+  applicationsetcontroller.enable.git.submodule: "false"
   applicationsetcontroller.log.level: "info"
   notificationscontroller.log.level: "info"


### PR DESCRIPTION
## Summary
- Adds `applicationsetcontroller.enable.git.submodule: "false"` to `argocd-cmd-params-cm`.
- Persists the live bootstrap fix required for ApplicationSet Git generators to avoid cloning the private `.planning` submodule.

## Root cause
#771 disabled submodules for repo-server, but the ApplicationSet controller has its own `ARGOCD_GIT_MODULES_ENABLED` env wired to `applicationsetcontroller.enable.git.submodule`. Without this key, ApplicationSet generation still attempted `git submodule update --init --recursive`.

## Validation
- `task apps:overlays:render project=admin namespace=argocd app=argocd cluster=bastion`
- Rendered `argocd-cmd-params-cm` contains both repo-server and ApplicationSet submodule-disable keys.
- Rendered ApplicationSet controller env sources `ARGOCD_GIT_MODULES_ENABLED` from `applicationsetcontroller.enable.git.submodule`.
- `kubectl apply --dry-run=server -f /private/tmp/argocd-followup-render.yaml`
- `git diff --check -- kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-cmd-params-cm.yaml`

## Live recovery already performed
- Applied the missing key to live `argocd-cmd-params-cm`.
- Restarted `argocd-repo-server` and `argocd-applicationset-controller`; both rolled out after deleting old pods to break single-node memory surge deadlocks.
- Verified all 57 ArgoCD Applications are now `Synced`; OpenClaw apps are `Healthy` and `Synced`.
