### PR TITLE
[codex] Use GPT-5.5 for OpenClaw

### DIFF
--- a/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/openclaw.json
+++ b/kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/openclaw.json
@@ -20,10 +20,10 @@
   "agents": {
     "defaults": {
       "models": {
-        "openai-codex/gpt-5.4": {}
+        "codex/gpt-5.5": {}
       },
       "model": {
-        "primary": "openai-codex/gpt-5.4"
+        "primary": "codex/gpt-5.5"
       },
       "memorySearch": {
         "provider": "openai",


### PR DESCRIPTION
## Summary
- Updates the OpenClaw bastion default model from `openai-codex/gpt-5.4` to `codex/gpt-5.5`.
- Removes the `openai-codex/...` model prefix that was driving Telegram message handling into an unregistered `codex` harness path.

## Root cause
Telegram transport was working: OpenClaw received direct Telegram messages and sent error replies. The runtime failed before generating a normal reply with `Requested agent harness "codex" is not registered.` The live model registry shows `codex/gpt-5.5` is available, while the Git config still pinned `openai-codex/gpt-5.4`.

## Validation
- Official OpenAI model docs identify `gpt-5.5` as the current flagship model for complex reasoning/coding.
- `openclaw models list --json` in the running pod shows `codex/gpt-5.5` available.
- `jq . kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/openclaw.json`
- `task apps:overlays:render project=admin namespace=openclaw app=openclaw cluster=bastion`
- Rendered `openclaw-config` contains `codex/gpt-5.5` and no `openai-codex/gpt-5.4`.
- `kubectl apply --dry-run=server -f /private/tmp/openclaw-model-render.yaml`
- `git diff --check -- kubernetes/deploy/admin/openclaw/openclaw/clusters/bastion/openclaw.json`

## UAT note
This addresses the Phase 1 UAT blocker where Telegram `/new` succeeded but normal messages returned the generic error response.
