### PR TITLE
[codex] right-size memory requests

### DIFF
--- a/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/patch-resources.yaml
+++ b/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/patch-resources.yaml
@@ -14,7 +14,7 @@ spec:
             memory: 2Gi
           requests:
             cpu: 500m
-            memory: 2Gi
+            memory: 1Gi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -31,7 +31,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 500m
-            memory: 512Mi
+            memory: 256Mi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -48,4 +48,4 @@ spec:
             memory: 512Mi
           requests:
             cpu: 1000m
-            memory: 512Mi
+            memory: 256Mi

--- a/kubernetes/deploy/home/media/lidarr/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/lidarr/clusters/bastion/values.yaml
@@ -42,6 +42,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 512Mi
           limits:
             memory: 1Gi
         securityContext:

--- a/kubernetes/deploy/home/media/navidrome/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/media/navidrome/clusters/bastion/deployment.yaml
@@ -66,8 +66,9 @@ spec:
           resources:
             requests:
               cpu: 10m
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
           livenessProbe:
             httpGet:
               path: /ping

--- a/kubernetes/deploy/home/media/overseerr/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/overseerr/clusters/bastion/values.yaml
@@ -37,8 +37,9 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 512Mi
           limits:
-            memory: 2Gi
+            memory: 1Gi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/deploy/home/media/prowlarr/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/prowlarr/clusters/bastion/values.yaml
@@ -42,6 +42,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 256Mi
           limits:
             memory: 512Mi
         securityContext:

--- a/kubernetes/deploy/home/media/radarr/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/radarr/clusters/bastion/values.yaml
@@ -54,6 +54,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 512Mi
           limits:
             memory: 1Gi
         securityContext:

--- a/kubernetes/deploy/home/media/sabnzbd/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/sabnzbd/clusters/bastion/values.yaml
@@ -46,8 +46,9 @@ controllers:
         resources:
           requests:
             cpu: 100m
+            memory: 1Gi
           limits:
-            memory: 8Gi
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kubernetes/deploy/home/media/sonarr/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/sonarr/clusters/bastion/values.yaml
@@ -54,6 +54,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 512Mi
           limits:
             memory: 1Gi
         securityContext:

--- a/kubernetes/deploy/home/media/tautulli/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/home/media/tautulli/clusters/bastion/values.yaml
@@ -26,6 +26,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 256Mi
           limits:
             memory: 512Mi
         securityContext: &securityContext
@@ -46,6 +47,7 @@ controllers:
         resources:
           requests:
             cpu: 10m
+            memory: 32Mi
           limits:
             memory: 128Mi
         securityContext: *securityContext

--- a/kubernetes/deploy/home/searxng/searxng/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/searxng/searxng/clusters/bastion/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           readinessProbe: *probe
           resources:
             limits:
-              memory: 4Gi
+              memory: 2Gi
             requests:
               cpu: 10m
               memory: 512Mi

--- a/kubernetes/deploy/monitoring/monitoring/victoria-logs/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/monitoring/monitoring/victoria-logs/clusters/bastion/kustomization.yaml
@@ -43,10 +43,10 @@ helmCharts:
         resources: # TODO: tune
           requests:
             cpu: 10m
-            memory: 512Mi
+            memory: 256Mi
           limits:
             cpu: 3000m
-            memory: 4Gi
+            memory: 1Gi
         securityContext:
           enabled: true
           allowPrivilegeEscalation: false

--- a/kubernetes/deploy/monitoring/monitoring/victoria-metrics/clusters/bastion/vmsingle.yaml
+++ b/kubernetes/deploy/monitoring/monitoring/victoria-metrics/clusters/bastion/vmsingle.yaml
@@ -30,6 +30,7 @@ spec:
   resources:
     requests:
       cpu: 200m
+      memory: 512Mi
     limits:
       cpu: 1
       memory: 2Gi
@@ -71,6 +72,7 @@ spec:
   resources:
     requests:
       cpu: 200m
+      memory: 1Gi
     limits:
       cpu: 1
       memory: 2Gi


### PR DESCRIPTION
## Summary

Right-size memory requests and selected limits for the single-node bastion cluster so new workloads have schedulable headroom without removing practical burst capacity.

Changes:
- Add explicit memory requests for media apps whose memory limits were implicitly becoming scheduler reservations.
- Lower oversized memory limits for sabnzbd, overseerr, navidrome, searxng, and victoria-logs based on observed usage.
- Reduce ArgoCD and VictoriaMetrics memory requests while keeping conservative limits where useful.

Expected impact:
- Frees roughly 14 GiB of requested memory on talos-master-0.
- Keeps limits above recent observed usage for the adjusted workloads.
- Leaves metamcp, openclaw, teslamate-db, and searxng request sizing largely intact where the audit showed higher usage or OOM history.

## Validation

- `yq e '.'` on all changed YAML files
- `git diff --check`
- `task apps:overlays:render` for all affected overlays
- `kubectl apply --dry-run=server` for all affected rendered overlays

Notes:
- Initial sandboxed render attempts failed DNS lookups for remote Helm/Git sources; reran with host/network access and renders passed.
- Server-side dry-runs emitted existing PodSecurity warnings for several media overlays, mostly seccomp/init container/NFS warnings. No dry-run failed, and these warnings are unrelated to the resource changes.
