### PR TITLE
[codex] Deploy Dograh phase 1 overlay

### DIFF
--- a/docs/dograh-runbook.md
+++ b/docs/dograh-runbook.md
@@ -44,6 +44,29 @@ CNPG_R2_DESTINATION_PATH=s3://restic-backups/dograh/
 MINIO_R2_TARGET=dograh-voice-audio
 ```
 
+Confirmed shared R2 field placement:
+
+| Field name | Dograh item status | Shared source |
+| --- | --- | --- |
+| `R2_ENDPOINT` | not present | `cloudflare-r2-generic` field `endpoint` |
+| `R2_ACCESS_KEY_ID` | not present | `cloudflare-r2-generic` field `access_key_id` |
+| `R2_SECRET_ACCESS_KEY` | not present | `cloudflare-r2-generic` field `secret_access_key` |
+
+### Confirmed Non-Secret Deployment Inputs
+
+```text
+ASTERISK_IMAGE: ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:984a02847c8fd9963b20dacdfb14be21e420b278914870ad14c5871eca0b5df7
+ASTERISK_IMAGE_SOURCE: https://github.com/jtcressy/docker-asterisk
+ASTERISK_STABLE_MAC: 02:8c:20:0c:1a:01
+ASTERISK_LAN_IP: 192.168.20.11
+ASTERISK_PJSIP_BINDADDR: 192.168.20.11
+ASTERISK_NETWORK_MODEL: direct-l2-multus
+CNPG_R2_DESTINATION_PATH: s3://restic-backups/dograh/
+MINIO_R2_TARGET: dograh-voice-audio
+```
+
+Asterisk uses direct Multus L2 by default. NAT-style `local_net`, `external_signaling_address`, and `external_media_address` are fallback-only knobs if direct L2 fails with evidence.
+
 ### Accepted Dograh Images
 
 ```text

--- a/docs/dograh-runbook.md
+++ b/docs/dograh-runbook.md
@@ -1,0 +1,52 @@
+# Dograh Runbook
+
+## Dograh Deployment Inputs
+
+Dograh v1 runs from one ArgoCD-discovered `home/dograh/dograh` overlay in namespace `dograh`. Static credentials are stored in 1Password and delivered through ExternalSecrets; this runbook records field names and has-value status only.
+
+### 1Password Field Contract
+
+Dograh-owned item: `1Password item dograh` in vault `jtcressy-net-infra`.
+
+| Field name | Status | Used by |
+| --- | --- | --- |
+| `POSTGRES_USER` | has value | App database username and init contract |
+| `POSTGRES_PASS` | has value | App database credential and init contract |
+| `POSTGRES_PASSWORD` | has value | Compatibility field retained on the item |
+| `POSTGRES_SUPER_PASS` | has value | CNPG superuser mapping below, not `dograh-secret` |
+| `VALKEY_PASSWORD` | has value | Valkey auth and `REDIS_URL` |
+| `MINIO_ROOT_USER` | has value | MinIO root user and Dograh MinIO access key |
+| `MINIO_ROOT_PASSWORD` | has value | MinIO root credential and Dograh MinIO secret key |
+| `OSS_JWT_SECRET` | has value | Dograh OSS session signing |
+| `ASTERISK_ARI_PASSWORD` | has value | Asterisk ARI and Dograh ARI provider configuration |
+| `UNIFI_TALK_SIP_SERVER` | has value | Asterisk UniFi Talk registration |
+| `UNIFI_TALK_SIP_USERNAME` | has value | Asterisk UniFi Talk registration |
+| `UNIFI_TALK_SIP_PASSWORD` | has value | Asterisk UniFi Talk registration |
+| `UNIFI_TALK_SIP_EXTENSION` | has value | Dograh inbound call assignment |
+| `GEMINI_API_KEY` | has value; stored for future use, not wired into v1 runtime manifests | Future workflow work |
+
+CNPG superuser mapping: `POSTGRES_SUPER_PASS -> dograh-db-superuser/password`. Plan 02 owns the Dograh-scoped `dograh-db-superuser` Secret, and Plan 04 consumes that key only from init-only database bootstrap.
+
+### Shared Cloudflare R2 Source
+
+Shared R2 credentials stay deduplicated in `cloudflare-r2-generic`; do not copy them into the Dograh item.
+
+| Shared item | Field name | Status | Later use |
+| --- | --- | --- | --- |
+| `cloudflare-r2-generic` | `endpoint` | has value | R2 endpoint remoteRef |
+| `cloudflare-r2-generic` | `access_key_id` | has value | R2 access key remoteRef |
+| `cloudflare-r2-generic` | `secret_access_key` | has value | R2 secret key remoteRef |
+
+Non-secret R2 targets:
+
+```text
+CNPG_R2_DESTINATION_PATH=s3://restic-backups/dograh/
+MINIO_R2_TARGET=dograh-voice-audio
+```
+
+### Accepted Dograh Images
+
+```text
+DOGRAH_API_IMAGE=ghcr.io/dograh-hq/dograh-api:1.29.0@sha256:f338d55d56acad6e8ef4054aa8d0bc5d74884f3418bbe24d54235d2378a3fdbe
+DOGRAH_UI_IMAGE=ghcr.io/dograh-hq/dograh-ui:1.29.0@sha256:54da6c9877dcdae1d0c37aa4c28a7ba1689dc44a484508f7b1c47b1f2c133deb
+```

--- a/docs/dograh-runbook.md
+++ b/docs/dograh-runbook.md
@@ -2,74 +2,259 @@
 
 ## Dograh Deployment Inputs
 
-Dograh v1 runs from one ArgoCD-discovered `home/dograh/dograh` overlay in namespace `dograh`. Static credentials are stored in 1Password and delivered through ExternalSecrets; this runbook records field names and has-value status only.
+Dograh v1 is one ArgoCD-discovered app under `kubernetes/deploy/home/dograh/dograh/clusters/bastion` in namespace `dograh`.
 
-### 1Password Field Contract
+Primary local commands:
 
-Dograh-owned item: `1Password item dograh` in vault `jtcressy-net-infra`.
-
-| Field name | Status | Used by |
-| --- | --- | --- |
-| `POSTGRES_USER` | has value | App database username and init contract |
-| `POSTGRES_PASS` | has value | App database credential and init contract |
-| `POSTGRES_PASSWORD` | has value | Compatibility field retained on the item |
-| `POSTGRES_SUPER_PASS` | has value | CNPG superuser mapping below, not `dograh-secret` |
-| `VALKEY_PASSWORD` | has value | Valkey auth and `REDIS_URL` |
-| `MINIO_ROOT_USER` | has value | MinIO root user and Dograh MinIO access key |
-| `MINIO_ROOT_PASSWORD` | has value | MinIO root credential and Dograh MinIO secret key |
-| `OSS_JWT_SECRET` | has value | Dograh OSS session signing |
-| `ASTERISK_ARI_PASSWORD` | has value | Asterisk ARI and Dograh ARI provider configuration |
-| `UNIFI_TALK_SIP_SERVER` | has value | Asterisk UniFi Talk registration |
-| `UNIFI_TALK_SIP_USERNAME` | has value | Asterisk UniFi Talk registration |
-| `UNIFI_TALK_SIP_PASSWORD` | has value | Asterisk UniFi Talk registration |
-| `UNIFI_TALK_SIP_EXTENSION` | has value | Dograh inbound call assignment |
-| `GEMINI_API_KEY` | has value; stored for future use, not wired into v1 runtime manifests | Future workflow work |
-
-CNPG superuser mapping: `POSTGRES_SUPER_PASS -> dograh-db-superuser/password`. Plan 02 owns the Dograh-scoped `dograh-db-superuser` Secret, and Plan 04 consumes that key only from init-only database bootstrap.
-
-### Shared Cloudflare R2 Source
-
-Shared R2 credentials stay deduplicated in `cloudflare-r2-generic`; do not copy them into the Dograh item.
-
-| Shared item | Field name | Status | Later use |
-| --- | --- | --- | --- |
-| `cloudflare-r2-generic` | `endpoint` | has value | R2 endpoint remoteRef |
-| `cloudflare-r2-generic` | `access_key_id` | has value | R2 access key remoteRef |
-| `cloudflare-r2-generic` | `secret_access_key` | has value | R2 secret key remoteRef |
-
-Non-secret R2 targets:
-
-```text
-CNPG_R2_DESTINATION_PATH=s3://restic-backups/dograh/
-MINIO_R2_TARGET=dograh-voice-audio
+```bash
+task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
+task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion > /tmp/dograh-full-render.yaml
+kubectl apply --dry-run=server -f /tmp/dograh-full-render.yaml
+task apps:overlays:status project=home namespace=dograh app=dograh cluster=bastion
 ```
 
-Confirmed shared R2 field placement:
-
-| Field name | Dograh item status | Shared source |
-| --- | --- | --- |
-| `R2_ENDPOINT` | not present | `cloudflare-r2-generic` field `endpoint` |
-| `R2_ACCESS_KEY_ID` | not present | `cloudflare-r2-generic` field `access_key_id` |
-| `R2_SECRET_ACCESS_KEY` | not present | `cloudflare-r2-generic` field `secret_access_key` |
-
-### Confirmed Non-Secret Deployment Inputs
+Public and internal endpoints:
 
 ```text
-ASTERISK_IMAGE: ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:984a02847c8fd9963b20dacdfb14be21e420b278914870ad14c5871eca0b5df7
-ASTERISK_IMAGE_SOURCE: https://github.com/jtcressy/docker-asterisk
-ASTERISK_STABLE_MAC: 02:8c:20:0c:1a:01
-ASTERISK_LAN_IP: 192.168.20.11
-ASTERISK_PJSIP_BINDADDR: 192.168.20.11
-ASTERISK_NETWORK_MODEL: direct-l2-multus
-CNPG_R2_DESTINATION_PATH: s3://restic-backups/dograh/
-MINIO_R2_TARGET: dograh-voice-audio
+Dograh UI/API=https://dograh.tailnet-4d89.ts.net
+PUBLIC_BASE_URL=https://dograh.tailnet-4d89.ts.net
+MINIO_PUBLIC_ENDPOINT=https://dograh-minio.tailnet-4d89.ts.net
+Dograh ARI endpoint=http://dograh-asterisk.dograh.svc.cluster.local:8088
+Asterisk websocket URI=ws://dograh-api.dograh.svc.cluster.local:8000/api/v1/telephony/ws/ari
 ```
 
-Asterisk uses direct Multus L2 by default. NAT-style `local_net`, `external_signaling_address`, and `external_media_address` are fallback-only knobs if direct L2 fails with evidence.
-
-### Accepted Dograh Images
+Runtime pins and LAN inputs:
 
 ```text
 DOGRAH_API_IMAGE=ghcr.io/dograh-hq/dograh-api:1.29.0@sha256:f338d55d56acad6e8ef4054aa8d0bc5d74884f3418bbe24d54235d2378a3fdbe
 DOGRAH_UI_IMAGE=ghcr.io/dograh-hq/dograh-ui:1.29.0@sha256:54da6c9877dcdae1d0c37aa4c28a7ba1689dc44a484508f7b1c47b1f2c133deb
+Asterisk image=ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:984a02847c8fd9963b20dacdfb14be21e420b278914870ad14c5871eca0b5df7
+Asterisk image source=https://github.com/jtcressy/docker-asterisk
+Multus MAC=02:8c:20:0c:1a:01
+Multus IP=192.168.20.11
+direct-L2 bind=ASTERISK_PJSIP_BINDADDR=192.168.20.11
+Stasis app=dograh
+websocket client=dograh
+extension 7000
+```
+
+Static credentials are stored in the `dograh` 1Password item and delivered through ExternalSecrets. Do not print or paste secret values into tickets, docs, manifests, or validation notes.
+
+Required 1Password-backed fields are `POSTGRES_USER`, `POSTGRES_PASS`, `POSTGRES_PASSWORD`, `POSTGRES_SUPER_PASS`, `VALKEY_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `OSS_JWT_SECRET`, `ASTERISK_ARI_PASSWORD`, `UNIFI_TALK_SIP_SERVER`, `UNIFI_TALK_SIP_USERNAME`, `UNIFI_TALK_SIP_PASSWORD`, and `UNIFI_TALK_SIP_EXTENSION`. Shared Cloudflare R2 credentials stay in the `cloudflare-r2-generic` item and are referenced by field name only.
+
+## Initial Admin Access
+
+Open Dograh through the tailnet URL:
+
+```text
+https://dograh.tailnet-4d89.ts.net
+```
+
+Use the local Dograh bootstrap flow to create the initial admin account after the API and UI are healthy. The admin credential is app-local state; do not store it in Git or in this runbook.
+
+Minimum access checks:
+
+```bash
+kubectl -n dograh rollout status deploy/dograh-api deploy/dograh-ui
+kubectl -n dograh get deploy dograh-api dograh-ui
+kubectl -n dograh get svc dograh-api dograh-ui
+kubectl -n dograh logs deploy/dograh-api --tail=100
+kubectl -n dograh logs deploy/dograh-ui --tail=100
+```
+
+The API health endpoint is exposed through the UI/API host under `/api/v1/health` after Tailscale ingress is synced.
+
+## Authentication Posture
+
+Dograh v1 uses `AUTH_PROVIDER=local` because generic OIDC/tsidp support was not found in the current Dograh runtime. Tailscale ingress keeps the UI/API private to the tailnet, but Dograh authentication remains Dograh-local.
+
+Operational expectations:
+
+- Treat tailnet access as the network boundary and Dograh local auth as the application boundary.
+- Do not add tsidp or other OIDC settings unless Dograh gains a supported generic OIDC provider.
+- Do not enable public Funnel for this app.
+- Rotate the app-local admin credential through Dograh, not through GitOps.
+
+## Telephony Provider Setup
+
+Asterisk runs as the separate `dograh-asterisk` workload. The image source is `https://github.com/jtcressy/docker-asterisk`, and the pinned image is:
+
+```text
+ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:984a02847c8fd9963b20dacdfb14be21e420b278914870ad14c5871eca0b5df7
+```
+
+The default network model is direct L2 through Multus/macvlan:
+
+```text
+Multus network=kube-system/macvlan-conf-dhcp
+interface=eth1
+MAC=02:8c:20:0c:1a:01
+LAN IP=192.168.20.11
+ASTERISK_PJSIP_BINDADDR=192.168.20.11
+```
+
+Do not use `hostNetwork`, `hostPort`, NodePort, localhost, or `host.docker.internal` for the v1 SIP/RTP path. NAT fields such as local net, external signaling address, and external media address are fallback-only settings if direct L2 fails with evidence.
+
+UniFi Talk SIP credentials are reused from the previous OpenClaw Voice setup through the `dograh` 1Password item by default. New UniFi Talk credential provisioning through browser automation is only needed if legacy credential reuse fails.
+
+Dograh ARI provider settings:
+
+```text
+ARI Endpoint URL=http://dograh-asterisk.dograh.svc.cluster.local:8088
+ARI username=dograh
+Stasis app=dograh
+WebSocket client name=dograh
+Phone number or extension=7000
+```
+
+The ARI password comes from the `dograh` 1Password item and must match the Asterisk environment. The Asterisk websocket client connects inward to Dograh at:
+
+```text
+ws://dograh-api.dograh.svc.cluster.local:8000/api/v1/telephony/ws/ari
+```
+
+Provider checks:
+
+```bash
+kubectl -n dograh get pod -l app.kubernetes.io/name=dograh-asterisk -o jsonpath='{.items[0].metadata.annotations.k8s\.v1\.cni\.cncf\.io/network-status}'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'core show version'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'module show like chan_websocket'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'module show like res_websocket_client'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'module show like res_ari'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'module show like res_pjsip'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'http show status'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'pjsip show registrations'
+```
+
+## No-Tool Test Workflow
+
+The v1 no-tool workflow is infrastructure validation only, not the full Media Request Assistant per D-03. It should answer the inbound call, converse briefly, and prove that Dograh receives caller audio and returns model audio through Asterisk.
+
+Configure the workflow inside Dograh after the app is healthy:
+
+```text
+Workflow purpose=real inbound call infrastructure validation
+Tools=none
+Assigned telephony provider=Asterisk ARI
+Assigned phone number or extension=7000
+Expected behavior=brief spoken response without external tool calls
+```
+
+Do not add external media tooling, request tooling, or application-specific smoke cases to this v1 workflow.
+
+## Health And Logs
+
+Overlay and ArgoCD checks:
+
+```bash
+task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
+task apps:overlays:status project=home namespace=dograh app=dograh cluster=bastion
+kubectl -n dograh get all
+```
+
+API/UI checks:
+
+```bash
+kubectl -n dograh rollout status deploy/dograh-api deploy/dograh-ui
+kubectl -n dograh get deploy dograh-api dograh-ui
+kubectl -n dograh get svc dograh-api dograh-ui
+kubectl -n dograh logs deploy/dograh-api --tail=100
+kubectl -n dograh logs deploy/dograh-ui --tail=100
+```
+
+Database, cache, and object storage checks:
+
+```bash
+kubectl -n dograh get cluster dograh-db
+kubectl -n dograh get scheduledbackup dograh-db-backup
+kubectl -n dograh get deploy dograh-valkey
+kubectl -n dograh get tenant dograh-minio
+kubectl -n dograh get cronjob dograh-minio-r2-backup
+```
+
+Asterisk checks:
+
+```bash
+kubectl -n dograh rollout status deploy/dograh-asterisk
+kubectl -n dograh logs deploy/dograh-asterisk --tail=100
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'core show version'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'http show status'
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'pjsip show registrations'
+```
+
+## Backup And Restore
+
+CNPG database backups target Cloudflare R2 through the Dograh database backup resources. Confirm the CNPG cluster and scheduled backup exist:
+
+```bash
+kubectl -n dograh get cluster dograh-db
+kubectl -n dograh get scheduledbackup dograh-db-backup
+kubectl -n dograh describe scheduledbackup dograh-db-backup
+```
+
+Database restore uses CloudNativePG recovery from the R2 backup destination. Perform restore as a planned change with a separate manifest/update, preserve the current cluster until the recovery target is verified, and avoid printing database credentials.
+
+MinIO stores Dograh voice audio in the `voice-audio` bucket. Object-level backup copies objects to the Cloudflare R2 bucket/prefix `dograh-voice-audio` without delete propagation. Confirm the backup job:
+
+```bash
+kubectl -n dograh get tenant dograh-minio
+kubectl -n dograh get cronjob dograh-minio-r2-backup
+kubectl -n dograh create job --from=cronjob/dograh-minio-r2-backup dograh-minio-r2-backup-manual
+kubectl -n dograh logs job/dograh-minio-r2-backup-manual
+```
+
+MinIO object restore from R2 bucket/prefix `dograh-voice-audio` should copy objects back into local `voice-audio` after the Tenant is healthy. Use MinIO client aliases backed by Kubernetes secrets; do not include access keys in command history or docs.
+
+Valkey is disposable runtime state. If Valkey is lost, restart Dograh API workers after Valkey returns and allow queues/session cache to rebuild.
+
+Asterisk `/var/lib/asterisk`, `/var/log/asterisk`, and `/var/spool/asterisk` are intentionally non-durable for v1. Asterisk voicemail, recordings, and spool contents are not protected unless the user later requests voicemail or recording durability.
+
+## Rollback And Cutover
+
+Before cutover:
+
+```bash
+task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
+task apps:overlays:status project=home namespace=dograh app=dograh cluster=bastion
+kubectl -n dograh rollout status deploy/dograh-api deploy/dograh-ui deploy/dograh-asterisk
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'pjsip show registrations'
+```
+
+Cutover is only complete after the no-tool workflow is assigned to extension `7000` and a real inbound call passes. Keep the previous UniFi/OpenClaw Voice path available until the Dograh call path is proven.
+
+Rollback options:
+
+- Revert the Dograh GitOps commit if the overlay change is the cause.
+- Re-sync ArgoCD after revert and verify app health with the task status wrapper.
+- Return UniFi Talk routing to the previous known-good target if Asterisk registration or two-way audio fails.
+- Preserve CNPG and MinIO data while investigating unless a deliberate restore plan has been approved.
+
+Do not move the overlay to `disabled/` manually. Use the repo overlay tasks for app lifecycle operations.
+
+## Real Inbound Call Validation
+
+This section is the operator checklist for Task 3 live validation. Do not mark it complete from local render checks alone.
+
+Pre-call checks:
+
+```bash
+task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
+task apps:overlays:status project=home namespace=dograh app=dograh cluster=bastion
+kubectl -n dograh rollout status deploy/dograh-api deploy/dograh-ui deploy/dograh-asterisk
+kubectl -n dograh get cluster dograh-db
+kubectl -n dograh get tenant dograh-minio
+kubectl -n dograh get cronjob dograh-minio-r2-backup
+kubectl -n dograh exec deploy/dograh-asterisk -- asterisk -rx 'pjsip show registrations'
+```
+
+Call UAT:
+
+```text
+1. Confirm Dograh ARI provider uses http://dograh-asterisk.dograh.svc.cluster.local:8088.
+2. Confirm Stasis app dograh, websocket client dograh, and extension 7000 are configured.
+3. Confirm the no-tool workflow is assigned to extension 7000.
+4. Place a real inbound UniFi Talk call.
+5. Confirm Dograh hears caller audio.
+6. Confirm the caller hears Dograh's model response.
+7. Record pass/fail evidence without secret values.
 ```

--- a/docs/dograh-runbook.md
+++ b/docs/dograh-runbook.md
@@ -235,6 +235,17 @@ Do not move the overlay to `disabled/` manually. Use the repo overlay tasks for 
 
 This section is the operator checklist for Task 3 live validation. Do not mark it complete from local render checks alone.
 
+Current validation attempt, 2026-05-17T02:25:58Z:
+
+- PASS: `task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion` rendered the fully wired overlay locally.
+- PASS: forbidden-pattern scans found no app-template usage, host networking, Funnel, VolSync/restic MinIO backup resources, `mc mirror --remove`, or Compose-local host assumptions in the Dograh overlay.
+- PASS: `argocd login argocd.tailnet-4d89.ts.net --sso` completed successfully for the CLI.
+- PASS: `argocd app get argocd/metamcp-bastion --grpc-web` confirmed the logged-in CLI can inspect an existing app.
+- BLOCKED: `task apps:overlays:status project=home namespace=dograh app=dograh cluster=bastion` returned `PermissionDenied` because `argocd/dograh-bastion` is not generated yet.
+- BLOCKED: `kubectl -n argocd get applications.argoproj.io dograh-bastion` returned NotFound, and `argocd app list --grpc-web` did not include Dograh.
+- BLOCKED: `kubectl get namespace dograh` returned NotFound; `kubectl apply --dry-run=server -f /tmp/dograh-full-render.yaml` reached the cluster but failed because the namespace does not yet exist.
+- NOT RUN: rollout, Asterisk registration, Dograh UI workflow setup, and real inbound call UAT require the Dograh Application to exist and sync from the GitOps target revision.
+
 Pre-call checks:
 
 ```bash

--- a/kubernetes/argocd/projects/home.yaml
+++ b/kubernetes/argocd/projects/home.yaml
@@ -39,6 +39,9 @@ spec:
     - name: '*'
       namespace: metamcp
       server: '*'
+    - name: '*'
+      namespace: dograh
+      server: '*'
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/api-deployment.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/api-deployment.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dograh-api
+  labels:
+    app.kubernetes.io/name: dograh-api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dograh-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dograh-api
+    spec:
+      initContainers:
+        - name: init-db
+          image: ghcr.io/home-operations/postgres-init:18
+          env:
+            - name: INIT_POSTGRES_DBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: INIT_POSTGRES_DBNAME
+            - name: INIT_POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: INIT_POSTGRES_HOST
+            - name: INIT_POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: INIT_POSTGRES_USER
+            - name: INIT_POSTGRES_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: INIT_POSTGRES_PASS
+            - name: INIT_POSTGRES_SUPER_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-db-superuser
+                  key: password
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              memory: 128Mi
+        - name: init-vector
+          image: ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie
+          command:
+            - psql
+            - -v
+            - ON_ERROR_STOP=1
+            - -h
+            - dograh-db-rw.dograh.svc.cluster.local
+            - -U
+            - postgres
+            - -d
+            - dograh
+            - -c
+            - CREATE EXTENSION IF NOT EXISTS vector;
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-db-superuser
+                  key: password
+            - name: PGUSER
+              value: postgres
+          resources:
+            requests:
+              cpu: 10m
+            limits:
+              memory: 128Mi
+      containers:
+        - name: dograh-api
+          image: ghcr.io/dograh-hq/dograh-api:1.29.0@sha256:f338d55d56acad6e8ef4054aa8d0bc5d74884f3418bbe24d54235d2378a3fdbe
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: ENVIRONMENT
+              value: production
+            - name: DEPLOYMENT_MODE
+              value: oss
+            - name: AUTH_PROVIDER
+              value: local
+            - name: FASTAPI_WORKERS
+              value: "1"
+            - name: ARQ_WORKERS
+              value: "1"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: ENABLE_TELEMETRY
+              value: "false"
+            - name: ENABLE_AWS_S3
+              value: "false"
+            - name: MINIO_ENDPOINT
+              value: minio.dograh.svc.cluster.local:80
+            - name: MINIO_SECURE
+              value: "false"
+            - name: MINIO_BUCKET
+              value: voice-audio
+            - name: BACKEND_API_ENDPOINT
+              value: https://dograh.tailnet-4d89.ts.net
+            - name: PUBLIC_BASE_URL
+              value: https://dograh.tailnet-4d89.ts.net
+            - name: UI_APP_URL
+              value: https://dograh.tailnet-4d89.ts.net
+            - name: MINIO_PUBLIC_ENDPOINT
+              value: https://dograh-minio.tailnet-4d89.ts.net
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: DATABASE_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: REDIS_URL
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: MINIO_ACCESS_KEY
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: MINIO_SECRET_KEY
+            - name: OSS_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-secret
+                  key: OSS_JWT_SECRET
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - api-deployment.yaml
+  - ui-deployment.yaml
+  - services.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/services.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/services.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dograh-api
+  labels:
+    app.kubernetes.io/name: dograh-api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dograh-api
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dograh-ui
+  labels:
+    app.kubernetes.io/name: dograh-ui
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dograh-ui
+  ports:
+    - name: http
+      port: 3010
+      targetPort: 3010

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/ui-deployment.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/app/ui-deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dograh-ui
+  labels:
+    app.kubernetes.io/name: dograh-ui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dograh-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dograh-ui
+    spec:
+      containers:
+        - name: dograh-ui
+          image: ghcr.io/dograh-hq/dograh-ui:1.29.0@sha256:54da6c9877dcdae1d0c37aa4c28a7ba1689dc44a484508f7b1c47b1f2c133deb
+          ports:
+            - containerPort: 3010
+              name: http
+          env:
+            - name: BACKEND_URL
+              value: http://dograh-api.dograh.svc.cluster.local:8000
+            - name: ENABLE_TELEMETRY
+              value: "false"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3010
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3010
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/deployment.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/deployment.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dograh-asterisk
+  labels:
+    app.kubernetes.io/name: dograh-asterisk
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dograh-asterisk
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [
+            {
+              "name": "macvlan-conf-dhcp",
+              "namespace": "kube-system",
+              "interface": "eth1",
+              "mac": "02:8c:20:0c:1a:01"
+            }
+          ]
+      labels:
+        app.kubernetes.io/name: dograh-asterisk
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: asterisk
+          image: ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:984a02847c8fd9963b20dacdfb14be21e420b278914870ad14c5871eca0b5df7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: ari-http
+              containerPort: 8088
+              protocol: TCP
+            - name: sip-udp
+              containerPort: 5060
+              protocol: UDP
+          envFrom:
+            - secretRef:
+                name: dograh-asterisk-env
+          env:
+            - name: ASTERISK_REQUIRE_UNIFI
+              value: "true"
+            - name: ASTERISK_ARI_USERNAME
+              value: dograh
+            - name: ASTERISK_STASIS_APP
+              value: dograh
+            - name: ASTERISK_WS_CLIENT_NAME
+              value: dograh
+            - name: DOGRAH_ARI_WS_URI
+              value: ws://dograh-api.dograh.svc.cluster.local:8000/api/v1/telephony/ws/ari
+            - name: ASTERISK_WS_TLS_ENABLED
+              value: "no"
+            - name: ASTERISK_HTTP_BINDADDR
+              value: 0.0.0.0
+            - name: ASTERISK_HTTP_PORT
+              value: "8088"
+            - name: ASTERISK_PJSIP_BINDADDR
+              value: 192.168.20.11
+            - name: ASTERISK_PJSIP_PORT
+              value: "5060"
+            - name: ASTERISK_RTP_START
+              value: "10000"
+            - name: ASTERISK_RTP_END
+              value: "20000"
+            - name: UNIFI_TALK_ENDPOINT
+              value: unifi-talk
+            - name: UNIFI_TALK_INBOUND_CONTEXT
+              value: from-unifi-talk
+            - name: UNIFI_TALK_OUTBOUND_CONTEXT
+              value: from-dograh
+            - name: UNIFI_TALK_SIP_PORT
+              value: "5060"
+            - name: DOGRAH_INBOUND_EXTENSION
+              value: "7000"
+          volumeMounts:
+            - name: asterisk-templates
+              mountPath: /etc/asterisk/templates
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "DAC_OVERRIDE", "SETUID", "SETGID"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          startupProbe:
+            exec:
+              command: ["asterisk", "-rx", "core show version"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 18
+          livenessProbe:
+            exec:
+              command: ["asterisk", "-rx", "core show version"]
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["asterisk", "-rx", "core show version"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: asterisk-templates
+          configMap:
+            name: dograh-asterisk-templates

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-asterisk
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-asterisk-env
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ASTERISK_ARI_PASSWORD: "{{ .ASTERISK_ARI_PASSWORD }}"
+        UNIFI_TALK_SIP_SERVER: "{{ .UNIFI_TALK_SIP_SERVER }}"
+        UNIFI_TALK_SIP_USERNAME: "{{ .UNIFI_TALK_SIP_USERNAME }}"
+        UNIFI_TALK_SIP_PASSWORD: "{{ .UNIFI_TALK_SIP_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: dograh-asterisk-templates
+    files:
+      - templates/ari.conf.template
+      - templates/extensions.conf.template
+      - templates/http.conf.template
+      - templates/logger.conf.template
+      - templates/modules.conf.template
+      - templates/pjsip.conf.template
+      - templates/rtp.conf.template
+      - templates/websocket_client.conf.template
+resources:
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/service.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dograh-asterisk
+  labels:
+    app.kubernetes.io/name: dograh-asterisk
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dograh-asterisk
+  ports:
+    - name: ari-http
+      protocol: TCP
+      port: 8088
+      targetPort: 8088

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/ari.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/ari.conf.template
@@ -1,0 +1,9 @@
+[general]
+enabled = yes
+pretty = yes
+
+[${ASTERISK_ARI_USERNAME}]
+type = user
+read_only = no
+password = ${ASTERISK_ARI_PASSWORD}
+password_format = plain

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/extensions.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/extensions.conf.template
@@ -1,0 +1,27 @@
+[general]
+static = yes
+writeprotect = yes
+clearglobalvars = no
+
+[globals]
+DOGRAH_STASIS_APP = ${ASTERISK_STASIS_APP}
+UNIFI_TALK_ENDPOINT = ${UNIFI_TALK_ENDPOINT}
+
+[${UNIFI_TALK_INBOUND_CONTEXT}]
+exten => ${DOGRAH_INBOUND_EXTENSION},1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN})
+ same => n,Stasis(${ASTERISK_STASIS_APP})
+ same => n,Hangup()
+
+exten => s,1,NoOp(UniFi Talk inbound call for Dograh normalizing to ${DOGRAH_INBOUND_EXTENSION})
+ same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
+
+exten => _X.,1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN} normalizing to ${DOGRAH_INBOUND_EXTENSION})
+ same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
+
+exten => _+X.,1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN} normalizing to ${DOGRAH_INBOUND_EXTENSION})
+ same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
+
+[${UNIFI_TALK_OUTBOUND_CONTEXT}]
+exten => _X.,1,NoOp(Dograh outbound call to ${EXTEN} through UniFi Talk)
+ same => n,Dial(PJSIP/${EXTEN}@${UNIFI_TALK_ENDPOINT},60)
+ same => n,Hangup()

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/http.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/http.conf.template
@@ -1,0 +1,5 @@
+[general]
+enabled = yes
+bindaddr = ${ASTERISK_HTTP_BINDADDR}
+bindport = ${ASTERISK_HTTP_PORT}
+tlsenable = no

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/logger.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/logger.conf.template
@@ -1,0 +1,6 @@
+[general]
+dateformat = %F %T
+
+[logfiles]
+console => notice,warning,error,verbose
+messages => notice,warning,error

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/modules.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/modules.conf.template
@@ -1,0 +1,16 @@
+[modules]
+autoload = yes
+
+load => res_http_websocket.so
+load => res_websocket_client.so
+load => chan_websocket.so
+load => res_ari.so
+load => res_ari_asterisk.so
+load => res_ari_bridges.so
+load => res_ari_channels.so
+load => res_ari_events.so
+load => res_pjsip.so
+load => res_pjsip_endpoint_identifier_ip.so
+load => res_pjsip_outbound_registration.so
+load => res_pjsip_registrar.so
+load => codec_ulaw.so

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/pjsip.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/pjsip.conf.template
@@ -1,0 +1,54 @@
+[global]
+type = global
+user_agent = Dograh Asterisk Sidecar
+
+[transport-udp]
+type = transport
+protocol = udp
+bind = ${ASTERISK_PJSIP_BINDADDR}:${ASTERISK_PJSIP_PORT}
+
+[${UNIFI_TALK_ENDPOINT}-auth]
+type = auth
+auth_type = userpass
+username = ${UNIFI_TALK_SIP_USERNAME}
+password = ${UNIFI_TALK_SIP_PASSWORD}
+
+[${UNIFI_TALK_ENDPOINT}-aor]
+type = aor
+contact = sip:${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
+qualify_frequency = 30
+
+[${UNIFI_TALK_ENDPOINT}]
+type = endpoint
+transport = transport-udp
+context = ${UNIFI_TALK_INBOUND_CONTEXT}
+disallow = all
+allow = ulaw
+aors = ${UNIFI_TALK_ENDPOINT}-aor
+outbound_auth = ${UNIFI_TALK_ENDPOINT}-auth
+from_user = ${UNIFI_TALK_SIP_USERNAME}
+from_domain = ${UNIFI_TALK_SIP_SERVER}
+rewrite_contact = yes
+rtp_symmetric = yes
+force_rport = yes
+direct_media = no
+trust_id_inbound = yes
+send_rpid = yes
+
+[${UNIFI_TALK_ENDPOINT}-registration]
+type = registration
+transport = transport-udp
+outbound_auth = ${UNIFI_TALK_ENDPOINT}-auth
+server_uri = sip:${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
+client_uri = sip:${UNIFI_TALK_SIP_USERNAME}@${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
+contact_user = ${UNIFI_TALK_SIP_USERNAME}
+retry_interval = 60
+forbidden_retry_interval = 600
+expiration = 3600
+line = yes
+endpoint = ${UNIFI_TALK_ENDPOINT}
+
+[${UNIFI_TALK_ENDPOINT}-identify]
+type = identify
+endpoint = ${UNIFI_TALK_ENDPOINT}
+match = ${UNIFI_TALK_SIP_SERVER}

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/rtp.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/rtp.conf.template
@@ -1,0 +1,5 @@
+[general]
+rtpstart = ${ASTERISK_RTP_START}
+rtpend = ${ASTERISK_RTP_END}
+strictrtp = yes
+icesupport = no

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/websocket_client.conf.template
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/asterisk/templates/websocket_client.conf.template
@@ -1,0 +1,9 @@
+[${ASTERISK_WS_CLIENT_NAME}]
+type = websocket_client
+uri = ${DOGRAH_ARI_WS_URI}
+protocols = media
+connection_type = per_call_config
+connection_timeout = 500
+reconnect_interval = 500
+reconnect_attempts = 5
+tls_enabled = ${ASTERISK_WS_TLS_ENABLED}

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/backups/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/backups/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - minio-r2-backup.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/backups/minio-r2-backup.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/backups/minio-r2-backup.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-minio-r2-backup
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-minio-r2-backup
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        MINIO_ROOT_USER: "{{ .MINIO_ROOT_USER }}"
+        MINIO_ROOT_PASSWORD: "{{ .MINIO_ROOT_PASSWORD }}"
+        R2_ENDPOINT: "{{ .R2_ENDPOINT }}"
+        R2_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        R2_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: dograh
+  data:
+    - secretKey: R2_ENDPOINT
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: endpoint
+    - secretKey: R2_ACCESS_KEY_ID
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: access_key_id
+    - secretKey: R2_SECRET_ACCESS_KEY
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: secret_access_key
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dograh-minio-r2-backup
+spec:
+  schedule: "30 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: minio-r2-backup
+              image: quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z
+              imagePullPolicy: IfNotPresent
+              envFrom:
+                - secretRef:
+                    name: dograh-minio-r2-backup
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  mc alias set local http://minio.dograh.svc.cluster.local:80 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+                  mc alias set r2 "$R2_ENDPOINT" "$R2_ACCESS_KEY_ID" "$R2_SECRET_ACCESS_KEY"
+                  mc mirror --overwrite --summary local/voice-audio r2/dograh-voice-audio

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/ingress.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/ingress.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dograh
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - dograh
+  rules:
+    - host: dograh
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: dograh-api
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dograh-ui
+                port:
+                  number: 3010

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml
+namespace: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
@@ -1,5 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: dograh
 resources:
   - secrets
-namespace: dograh
+  - postgres
+  - valkey
+  - minio
+  - app
+  - ingress
+  - asterisk
+  - backups

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secrets
+namespace: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/minio/externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/minio/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-minio
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-minio-env-configuration
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        config.env: |-
+          export MINIO_ROOT_USER="{{ .MINIO_ROOT_USER }}"
+          export MINIO_ROOT_PASSWORD="{{ .MINIO_ROOT_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/minio/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/minio/kustomization.yaml
@@ -1,0 +1,54 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - externalsecret.yaml
+helmCharts:
+  - name: tenant
+    repo: https://operator.min.io/
+    version: 7.1.1
+    releaseName: dograh-minio
+    valuesInline:
+      tenant:
+        name: dograh-minio
+        image:
+          repository: quay.io/minio/minio
+          tag: RELEASE.2025-04-08T15-41-24Z
+          pullPolicy: IfNotPresent
+        configSecret:
+          name: dograh-minio-env-configuration
+          existingSecret: true
+        env:
+          - name: MINIO_API_CORS_ALLOW_ORIGIN
+            value: "*"
+        pools:
+          - name: pool-0
+            servers: 1
+            volumesPerServer: 1
+            size: 10Gi
+            storageClassName: zfs-nvme
+            storageLabels:
+              app.kubernetes.io/name: dograh
+              app.kubernetes.io/component: minio
+        mountPath: /export
+        subPath: /data
+        certificate:
+          requestAutoCert: false
+        features:
+          bucketDNS: false
+          enableSFTP: false
+        buckets:
+          - name: voice-audio
+            region: us-east-1
+        podManagementPolicy: Parallel
+        prometheusOperator: false
+      ingress:
+        api:
+          enabled: true
+          ingressClassName: tailscale
+          host: dograh-minio
+          tls:
+            - hosts:
+                - dograh-minio
+        console:
+          enabled: false

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/backup.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: dograh-db-backup
+spec:
+  schedule: "7 0 0 * * *"
+  immediate: true
+  suspend: false
+  cluster:
+    name: dograh-db

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - superuser-externalsecret.yaml
+  - r2-externalsecret.yaml
+  - pg-cluster.yaml
+  - backup.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/pg-cluster.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/pg-cluster.yaml
@@ -1,0 +1,35 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: dograh-db
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: dograh-db-superuser
+  storage:
+    size: 10Gi
+    storageClass: zfs-nvme
+  monitoring:
+    enablePodMonitor: true
+  nodeMaintenanceWindow:
+    reusePVC: true
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://restic-backups/dograh/
+      endpointURL: https://5d4249bf326be62396b18a9f6000341b.r2.cloudflarestorage.com
+      s3Credentials:
+        accessKeyId:
+          name: dograh-cnpg-r2-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: dograh-cnpg-r2-secret
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+        encryption: AES256
+      data:
+        compression: gzip
+        encryption: AES256
+    retentionPolicy: "7d"

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/r2-externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/r2-externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-cnpg-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-cnpg-r2-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: access_key_id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: secret_access_key

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/superuser-externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/postgres/superuser-externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-db-superuser
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-db-superuser
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        username: postgres
+        password: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/secrets/externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/secrets/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_DBNAME: dograh
+        INIT_POSTGRES_HOST: dograh-db-rw.dograh.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASS }}"
+        POSTGRES_USER: "{{ .POSTGRES_USER }}"
+        POSTGRES_PASSWORD: "{{ .POSTGRES_PASS }}"
+        DATABASE_URL: "postgresql+asyncpg://{{ .POSTGRES_USER }}:{{ .POSTGRES_PASS }}@dograh-db-rw.dograh.svc.cluster.local:5432/dograh"
+        REDIS_URL: "redis://:{{ .VALKEY_PASSWORD }}@dograh-valkey.dograh.svc.cluster.local:6379/0"
+        VALKEY_PASSWORD: "{{ .VALKEY_PASSWORD }}"
+        MINIO_ACCESS_KEY: "{{ .MINIO_ROOT_USER }}"
+        MINIO_SECRET_KEY: "{{ .MINIO_ROOT_PASSWORD }}"
+        OSS_JWT_SECRET: "{{ .OSS_JWT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: dograh

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/secrets/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/valkey/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/valkey/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+helmCharts:
+  - name: valkey
+    repo: https://valkey.io/valkey-helm/
+    version: 0.9.4
+    releaseName: dograh-valkey
+    valuesInline:
+      fullnameOverride: dograh-valkey
+      auth:
+        enabled: true
+        existingSecret: dograh-secret
+        existingSecretPasswordKey: VALKEY_PASSWORD
+        usersExistingSecret: dograh-secret
+        aclUsers:
+          default:
+            permissions: "~* &* +@all"
+            passwordKey: VALKEY_PASSWORD
+      dataStorage:
+        enabled: false
+      metrics:
+        enabled: false


### PR DESCRIPTION
## Summary

Implements Dograh phase 1 GitOps manifests for the home cluster:

- adds the Dograh overlay shell, AppProject destination, and ExternalSecret contract
- declares CNPG/PostgreSQL with pgvector bootstrap, Valkey, MinIO, and object-level MinIO-to-R2 backup
- deploys Dograh API/UI with private Tailscale ingress
- deploys the external pinned Asterisk image as a separate Multus/macvlan workload with cluster-internal ARI
- expands `docs/dograh-runbook.md` with bootstrap, auth, telephony, backup/restore, rollback, and call-validation guidance
- advances the private `.planning` submodule pointer for the Dograh workstream

## Validation

- `task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion`
- `git diff --check`
- Guard scans for forbidden app-template, host networking, public Funnel, VolSync/restic MinIO backup resources, `mc mirror --remove`, secret values, and deferred media workflow/tool content
- `argocd login argocd.tailnet-4d89.ts.net --sso`
- `argocd app get argocd/metamcp-bastion --grpc-web`

## Known Gate

Final live validation is intentionally not marked complete yet. `argocd/dograh-bastion` and namespace `dograh` do not exist until this branch is on the GitOps target revision and ApplicationSet generates the app. After merge/sync, remaining validation is ArgoCD status, Kubernetes rollouts, Asterisk UniFi Talk registration, Dograh no-tool workflow setup, and real inbound two-way call UAT.
