### PR TITLE
Fix Dograh rollout ingress details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The ApplicationSet uses `applicationsSync: sync`. **Moving an overlay from `clus
 
 - Always use `task apps:overlays:disable` — never `git mv` to disable an overlay manually
 - Use `task apps:overlays:diff` to preview changes before committing
+- When introducing a new namespace for an app overlay, update the matching ArgoCD `AppProject` destination before expecting the ApplicationSet app to sync. Prefer `task apps:projects:dest:add` or the existing project YAML pattern, and verify the live `AppProject` has synced before troubleshooting the app rollout.
 
 ## Helm Charts
 

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/ingress.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/ingress/ingress.yaml
@@ -3,6 +3,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: dograh
+  annotations:
+    link.argocd.argoproj.io/external-link: https://dograh.tailnet-4d89.ts.net
 spec:
   ingressClassName: tailscale
   tls:
@@ -12,7 +14,7 @@ spec:
     - host: dograh
       http:
         paths:
-          - path: /api
+          - path: /api/v1
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary
- Add Argo CD external-link annotation for the Dograh Tailscale URL
- Route only /api/v1 to FastAPI so Next.js /api/config and /api/auth routes stay on the UI
- Document the AppProject namespace destination reminder in AGENTS.md

## Verification
- task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
- task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion | kubectl apply --dry-run=server -f -