### PR TITLE
feat(dograh): deploy jellyseerr adapter manifests

### DIFF
--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/deployment.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/deployment.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dograh-jellyseerr-adapter
+  labels:
+    app.kubernetes.io/name: dograh-jellyseerr-adapter
+    app.kubernetes.io/part-of: dograh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dograh-jellyseerr-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dograh-jellyseerr-adapter
+        app.kubernetes.io/part-of: dograh
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: adapter
+          image: ghcr.io/jtcressy/dograh-jellyseerr-adapter:sha-efcca62@sha256:cb9233cb8cdb5a11cb1d986abb8305b5ea916664c80edfda438a34b7e9291233
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: JELLYSEERR_BASE_URL
+              value: http://overseerr.media.svc.cluster.local:5055
+            - name: JELLYSEERR_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-jellyseerr-adapter-secret
+                  key: JELLYSEERR_API_KEY
+            - name: JELLYSEERR_API_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-jellyseerr-adapter-secret
+                  key: JELLYSEERR_API_USER
+            - name: SEARCH_RESULT_LIMIT
+              value: "3"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/externalsecret.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-jellyseerr-adapter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-jellyseerr-adapter-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        JELLYSEERR_API_KEY: "{{ .OVERSEERR_API_KEY }}"
+        JELLYSEERR_API_USER: "{{ .DOGRAH_AGENT_USER_ID }}"
+  dataFrom:
+    - extract:
+        key: overseerr

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/service.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dograh-jellyseerr-adapter
+  labels:
+    app.kubernetes.io/name: dograh-jellyseerr-adapter
+    app.kubernetes.io/part-of: dograh
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dograh-jellyseerr-adapter
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - app
   - ingress
   - asterisk
+  - jellyseerr-adapter
   - backups


### PR DESCRIPTION
## Summary
- add raw Kustomize Deployment, Service, ExternalSecret, and component kustomization for dograh-jellyseerr-adapter
- wire the adapter into the existing Dograh bastion overlay
- use digest-pinned image ghcr.io/jtcressy/dograh-jellyseerr-adapter:sha-efcca62@sha256:cb9233cb8cdb5a11cb1d986abb8305b5ea916664c80edfda438a34b7e9291233

## Verification
- kustomize build --enable-helm kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter
- task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion
- static rg scans for private service, digest image, overseerr credential projection, and forbidden exposure/build patterns

Live ArgoCD sync and rollout checks are intentionally deferred to Plan 02-06.