### PR TITLE
fix(dograh): update jellyseerr adapter image

### DIFF
--- a/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/deployment.yaml
+++ b/kubernetes/deploy/home/dograh/dograh/clusters/bastion/jellyseerr-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: adapter
-          image: ghcr.io/jtcressy/dograh-jellyseerr-adapter:sha-efcca62@sha256:cb9233cb8cdb5a11cb1d986abb8305b5ea916664c80edfda438a34b7e9291233
+          image: ghcr.io/jtcressy/dograh-jellyseerr-adapter:sha-12579b3@sha256:f91cec139a51bf039c04abc2c98d32df8d29626c721bae51a234dcf56544e59d
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Updates the Dograh Jellyseerr adapter image to sha-12579b3, which fixes Jellyseerr search queries containing spaces by encoding them as percent escapes.\n\nVerification:\n- task apps:overlays:render project=home namespace=dograh app=dograh cluster=bastion\n- adapter repo: 26 passed\n- adapter repo: ruff clean