### PR TITLE
fix(lidarr): set volsync restic cacheCapacity to 8Gi

### DIFF
--- a/kubernetes/deploy/home/media/lidarr/clusters/bastion/persistence.yaml
+++ b/kubernetes/deploy/home/media/lidarr/clusters/bastion/persistence.yaml
@@ -50,6 +50,7 @@ spec:
     accessModes: ["ReadWriteOnce"]
     storageClassName: zfs-nvme
     cacheStorageClassName: zfs-nvme
+    cacheCapacity: 8Gi # restic metadata cache outgrew the 1Gi volsync default (repo is ~9.4GiB / 50k files)
     volumeSnapshotClassName: zfs-nvme-snapshot
     moverSecurityContext:
       runAsUser: 568
@@ -72,6 +73,7 @@ spec:
     accessModes: ["ReadWriteOnce"]
     storageClassName: zfs-nvme
     cacheStorageClassName: zfs-nvme
+    cacheCapacity: 8Gi # restic metadata cache outgrew the 1Gi volsync default (repo is ~9.4GiB / 50k files)
     volumeSnapshotClassName: zfs-nvme-snapshot
     moverSecurityContext:
       runAsUser: 568


### PR DESCRIPTION
## Problem

`volsync-src-lidarr-rsrc-*` mover pods in the `media` namespace fail every few minutes and accumulate, exhausting the node's 110-pod kubelet cap. The mover logs show:

```
Fatal: unable to save snapshot: Copy: write /cache/.../data/c5/tmp-1262803107: no space left on device
```

## Root cause

No `cacheCapacity` is set on the lidarr `ReplicationSource`/`ReplicationDestination`, so volsync provisioned the restic cache PVC (`volsync-src-lidarr-rsrc-cache`) at its 1Gi default. The lidarr restic repo has grown to ~9.4GiB / 50k files (mostly `MediaCover`), and restic's metadata cache no longer fits, so every backup attempt dies at ~80% and the Job retries indefinitely.

## Fix

Set `cacheCapacity: 8Gi` on both the `ReplicationSource` and `ReplicationDestination`.

## Post-merge note

The existing 1Gi `volsync-src-lidarr-rsrc-cache` PVC may need a one-time delete (it is a disposable cache) so volsync recreates it at 8Gi, since volsync does not resize existing cache PVCs. Once the backup succeeds, the Job completes and the failed pods are cleaned up.

No other app currently sets `cacheCapacity`; lidarr is just the first repo to outgrow the default. Worth keeping in mind if other movers start failing the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)