### PR TITLE
fix(lidarr): expand config PVC to 20Gi

### DIFF
--- a/kubernetes/deploy/home/media/lidarr/clusters/bastion/persistence.yaml
+++ b/kubernetes/deploy/home/media/lidarr/clusters/bastion/persistence.yaml
@@ -34,7 +34,7 @@ spec:
     name: lidarr-rdst
   resources:
     requests:
-      storage: 10Gi
+      storage: 20Gi
   storageClassName: zfs-nvme
 ---
 apiVersion: volsync.backube/v1alpha1
@@ -56,7 +56,7 @@ spec:
       runAsUser: 568
       runAsGroup: 568
       fsGroup: 568
-    capacity: 10Gi # must match the PersistentVolumeClaim `.resources.requests.storage` size above
+    capacity: 20Gi # must match the PersistentVolumeClaim `.resources.requests.storage` size above
 ---
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource


### PR DESCRIPTION
## Problem

The lidarr Deployment has been in CrashLoopBackOff for **9 days** (2,613 restarts):

```
NzbDrone.Common.Exceptions.LidarrStartupException: Lidarr failed to start: AppFolder /config is not writable
```

## Root cause

The `lidarr` config PVC is 10Gi and holds ~9.45GiB / 50k files (mostly `MediaCover` album art, per the volsync restic backup manifest). For a non-root process (uid 568) on ext4 the volume is effectively full, so Lidarr's startup write-test fails. This is the same data growth that overflowed the volsync restic cache (#835) — one growth event, two symptoms.

## Fix

Expand the config PVC 10Gi → 20Gi. `zfs-nvme` (democratic-csi) has `allowVolumeExpansion: true`, so the zvol and ext4 filesystem expand online and Lidarr should start on the next restart. Also bumps the `ReplicationDestination` restore `capacity` to match per the inline comment.

## Verification

After sync: `kubectl -n media get pvc lidarr` shows 20Gi, the lidarr pod exits CrashLoopBackOff, and `/ping` readiness goes healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)