### PR TITLE
feat(talos): raise bastion kubelet maxPods to 200

### DIFF
--- a/kubernetes/clusters/bastion/talos/talconfig.yaml
+++ b/kubernetes/clusters/bastion/talos/talconfig.yaml
@@ -186,6 +186,8 @@ patches:
     kubelet:
       extraArgs:
         feature-gates: ImageVolume=true
+      extraConfig:
+        maxPods: 200 # node podCIDR is a /24 (~250 usable pod IPs); keep below ~230
       nodeIP:
         validSubnets:
           - 192.168.20.0/24


### PR DESCRIPTION
## Problem

The single bastion node runs chronically at the kubelet default of 110 pods. Right now there are exactly 110 non-terminal pods scheduled and volsync mover pods sit Pending with `Too many pods` (seen while fixing #835/#836). ~20% of the budget is single-service `ts-*` Tailscale proxy pods; consolidating those is deliberately deferred to the agentic-ai workstream's ingress migration.

## Change

Add `machine.kubelet.extraConfig.maxPods: 200` to the bastion talconfig global patch.

Why 200: the node podCIDR is `10.244.0.0/24` (~250 usable pod IPs, Cilium allocates from it), so 200 roughly doubles pod capacity while leaving IP headroom for churn during rolling updates. Going past ~230 would require re-IPAMing.

## Rollout (manual — not ArgoCD-synced)

```bash
task talos:genconfig cluster=bastion
task talos:apply cluster=bastion nodes=talos-master-0
```

Kubelet config change only: kubelet restarts, no node reboot, running workloads unaffected. Verify with `kubectl get node talos-master-0 -o jsonpath='{.status.capacity.pods}'` → 200, then the Pending volsync movers should schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)