### PR TITLE
feat(volsync): alert on out-of-sync replications and stuck mover pods

### DIFF
--- a/kubernetes/deploy/system/kube-system/volsync/clusters/_all/kustomization.yaml
+++ b/kubernetes/deploy/system/kube-system/volsync/clusters/_all/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system
 
+resources:
+- prometheusrule.yaml
+
 helmCharts:
 - name: volsync
   repo: https://backube.github.io/helm-charts/

--- a/kubernetes/deploy/system/kube-system/volsync/clusters/_all/prometheusrule.yaml
+++ b/kubernetes/deploy/system/kube-system/volsync/clusters/_all/prometheusrule.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volsync-alerts
+  namespace: kube-system
+spec:
+  groups:
+    - name: volsync
+      rules:
+        - alert: VolSyncVolumeOutOfSync
+          expr: volsync_volume_out_of_sync == 1
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: "VolSync replication {{ $labels.obj_namespace }}/{{ $labels.obj_name }} is out of sync"
+            description: >-
+              {{ $labels.obj_namespace }}/{{ $labels.obj_name }} has missed its sync
+              deadline for over 1 hour. Check the ReplicationSource/Destination status
+              and mover pods — common causes are stuck VolumeSnapshot/clone teardown,
+              iSCSI attach failures, restic cache exhaustion, or node pod-cap saturation.
+        - alert: VolSyncMoverPodStuck
+          expr: sum by (namespace, pod, phase) (kube_pod_status_phase{pod=~"volsync-(src|dst)-.*", phase=~"Pending|Failed"} == 1) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "VolSync mover pod {{ $labels.namespace }}/{{ $labels.pod }} stuck in {{ $labels.phase }}"
+            description: >-
+              Mover pod {{ $labels.namespace }}/{{ $labels.pod }} has been
+              {{ $labels.phase }} for 30 minutes. Pending usually means an unattachable
+              volume or pod-cap exhaustion; Failed pods accumulating means the backup
+              itself is erroring (check pod logs).


### PR DESCRIPTION
## Problem

VolSync failures keep happening silently. Most recently:
- `overseerr-rsrc` was wedged for **32 days** (stale clone with a broken iSCSI target) — `volsync_volume_out_of_sync` was `1` the entire time, but no alert rule watches it
- `lidarr-rsrc` movers error-looped every ~5 minutes until failed pods exhausted the node's pod cap

## Change

Adds `volsync-alerts` PrometheusRule to the volsync overlay (VictoriaMetrics operator auto-converts it to a VMRule; vmalert has `selectAllByDefault: true` and routes to Alertmanager):

| Alert | Condition | Severity |
|---|---|---|
| VolSyncVolumeOutOfSync | `volsync_volume_out_of_sync == 1` for 1h | critical |
| VolSyncMoverPodStuck | mover pod Pending/Failed for 30m | warning |

Metric verified live: 22 series with `obj_name`/`obj_namespace` labels. `kube_pod_status_phase` comes from kube-state-metrics (already deployed via kps).

Kustomize build verified with `--enable-helm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)