### PR TITLE
feat(agentic-ai): OpenShell v0.0.59 gateway with tailnet GRPCRoute + tsidp OIDC (phase 2, wave 3)

### DIFF
--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# ExternalSecret for OpenShell OIDC credentials.
+# OpenShell validates inbound Bearer tokens against tsidp JWKS (auth-only mode) and does not
+# require a client_id/client_secret for token validation. This ExternalSecret is a placeholder
+# for future OIDC client credentials if OpenShell is configured with role-based access
+# (server.oidc.adminRole / server.oidc.userRole) or if a client registration is needed.
+# Create a 1Password item named "openshell" with any required fields before enabling dataFrom.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openshell-oidc-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: openshell-oidc-secret
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: openshell

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/externalsecret.yaml
@@ -1,10 +1,11 @@
 ---
 # ExternalSecret for OpenShell OIDC credentials.
 # OpenShell validates inbound Bearer tokens against tsidp JWKS (auth-only mode) and does not
-# require a client_id/client_secret for token validation. This ExternalSecret is a placeholder
-# for future OIDC client credentials if OpenShell is configured with role-based access
-# (server.oidc.adminRole / server.oidc.userRole) or if a client registration is needed.
-# Create a 1Password item named "openshell" with any required fields before enabling dataFrom.
+# require a client_id/client_secret for token validation. The synced secret holds placeholder
+# OIDC client credentials for future role-based access (server.oidc.adminRole / userRole) or
+# client registration.
+# Backing item EXISTS: 1Password item "openshell" in vault jtcressy-net-infra
+# (created 2026-06-10; fields: client_id, client_secret, notes) — this ExternalSecret syncs.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/gateway.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/gateway.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: openshell-gateway
+  namespace: openshell
+  annotations:
+    cert-manager.io/cluster-issuer: internal-ca
+spec:
+  gatewayClassName: eg-tailscale
+  listeners:
+    - name: grpc-tls
+      protocol: HTTPS
+      port: 443
+      hostname: "openshell-gw.tailnet-4d89.ts.net"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: openshell-gateway-tls
+      allowedRoutes:
+        namespaces:
+          from: Same  # GRPCRoute lives in openshell namespace (same as Gateway)
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: openshell-grpc-timeout
+  namespace: openshell
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      name: openshell
+  timeout:
+    http:
+      requestTimeout: 0s  # disable timeout for long-lived agent sessions

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshell
+
+resources:
+  - externalsecret.yaml
+  - gateway.yaml
+
+helmCharts:
+  - name: helm-chart
+    repo: oci://ghcr.io/nvidia/openshell
+    version: 0.0.59
+    releaseName: openshell
+    namespace: openshell
+    valuesFile: values.yaml

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: openshell
 resources:
   - externalsecret.yaml
   - gateway.yaml
+  - networkpolicy.yaml
 
 helmCharts:
   - name: helm-chart

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/networkpolicy.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/networkpolicy.yaml
@@ -1,0 +1,41 @@
+---
+# Gateway ingress lockdown. With server.disableTls=true the Envoy -> OpenShell hop is
+# plaintext gRPC, and the chart's own NetworkPolicy (openshell-sandbox-ssh) only selects
+# sandbox pods — the gateway Service would otherwise accept direct plaintext connections
+# from any pod in the cluster, bypassing the Envoy TLS/ingress path (PR #839 review).
+# Allowed: Envoy proxies (envoy-gateway-system) on gRPC 8080; OpenShell-managed sandbox
+# pods (any namespace, for gateway callbacks) on 8080; monitoring scrapes on 9090.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openshell-gateway-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: openshell
+      app.kubernetes.io/instance: openshell
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: envoy-gateway-system
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              openshell.ai/managed-by: openshell
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: 9090
+          protocol: TCP

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
@@ -9,12 +9,14 @@ grpcRoute:
 
 server:
   sandboxNamespace: ""      # defaults to release namespace (openshell); Phase 3 will add per-track routing
+  # Reverse-proxy mode: Envoy terminates tailnet TLS (cert-manager internal-ca) and forwards
+  # plaintext gRPC in-cluster; without this the server expects TLS/mTLS and rejects Envoy's
+  # plaintext connections (PR #839 review). In-cluster hop is bounded by NetworkPolicy.
+  disableTls: true
   oidc:
     issuer: "https://tsidp.tailnet-4d89.ts.net"
     audience: "openshell-cli"
     jwksTtl: 3600
-  tls:
-    certSecretName: openshell-server-tls
 
 certManager:
   enabled: true

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
@@ -1,0 +1,28 @@
+grpcRoute:
+  enabled: true
+  hostnames:
+    - "openshell-gw.tailnet-4d89.ts.net"
+  gateway:
+    create: false           # repo-managed Gateway in gateway.yaml
+    name: openshell-gateway
+    namespace: openshell
+
+server:
+  sandboxNamespace: ""      # defaults to release namespace (openshell); Phase 3 will add per-track routing
+  oidc:
+    issuer: "https://tsidp.tailnet-4d89.ts.net"
+    audience: "openshell-cli"
+    jwksTtl: 3600
+  tls:
+    certSecretName: openshell-server-tls
+
+certManager:
+  enabled: true
+  serverDnsNames:
+    - openshell
+    - openshell.openshell.svc
+    - openshell.openshell.svc.cluster.local
+    - localhost
+
+networkPolicy:
+  enabled: true

--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/values.yaml
@@ -18,6 +18,9 @@ server:
     audience: "openshell-cli"
     jwksTtl: 3600
 
+# Note: with certManager.enabled=true the chart's certgen hook automatically runs in
+# JWT-only mode (creates openshell-jwt-keys; cert-manager does not manage that secret).
+# cert-manager takes precedence for all TLS secrets — no pkiInitJob override needed (v0.0.59).
 certManager:
   enabled: true
   serverDnsNames:

--- a/kubernetes/deploy/system/cert-manager/cert-manager/clusters/_all/kustomization.yaml
+++ b/kubernetes/deploy/system/cert-manager/cert-manager/clusters/_all/kustomization.yaml
@@ -13,4 +13,10 @@ helmCharts:
       leaderElection:
         namespace: cert-manager
     installCRDs: true
+    # Gateway API shim: lets cert-manager honor cert-manager.io/cluster-issuer
+    # annotations on Gateway resources (used by openshell-gateway TLS).
+    config:
+      apiVersion: controller.config.cert-manager.io/v1alpha1
+      kind: ControllerConfiguration
+      enableGatewayAPI: true
   version: v1.20.0


### PR DESCRIPTION
## Summary

Wave 3 of the agentic-ai **Agent Sandbox Platform**: the NVIDIA OpenShell agent gateway, reachable over the tailnet — no `kubectl port-forward`.

- **OpenShell v0.0.59** via OCI Helm chart `oci://ghcr.io/nvidia/openshell/helm-chart` in the `openshell` namespace (`agentic-ai` AppProject; destination pre-registered in #833)
- **Repo-managed Gateway** `openshell-gateway` (class `eg-tailscale` from #833): HTTPS :443 for `openshell-gw.tailnet-4d89.ts.net`, TLS from cert-manager via `internal-ca` ClusterIssuer
- **GRPCRoute** (chart-managed, `grpcRoute.gateway.create: false`) routing OpenShell's gRPC endpoint through Envoy; `BackendTrafficPolicy` disables request timeout for long-lived gRPC streams
- **OIDC** validation against existing tsidp (`https://tsidp.tailnet-4d89.ts.net`)
- **ExternalSecret** placeholder from `ClusterSecretStore/onepassword`, item `openshell`

### ⚠ Pre-merge requirement
The ExternalSecret expects a 1Password item named **`openshell`** — create it (placeholder fields are fine) before ArgoCD sync, or the ExternalSecret will fail to reconcile.

### Verification after merge + sync
```
kubectl -n openshell rollout status statefulset/openshell
kubectl get grpcroute -n openshell   # Accepted: True
kubectl get certificate -n openshell # Ready
kubectl -n envoy-gateway-system get svc -l gateway.envoyproxy.io/owning-gateway-name=openshell-gateway
curl -k https://openshell-gw.tailnet-4d89.ts.net:443   # TLS/gRPC response, not connection refused
```

Notes: chart tag on GHCR is `0.0.59` (no `v` prefix) and the OCI chart name is `helm-chart` — both verified with `helm pull`. Follow-up PR: reference track overlay + GC verification (wave 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)