### PR TITLE
fix(openshell): pin StatefulSet PVC to zfs-nvme storage class

### DIFF
--- a/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/openshell/openshell/clusters/bastion/kustomization.yaml
@@ -15,3 +15,14 @@ helmCharts:
     releaseName: openshell
     namespace: openshell
     valuesFile: values.yaml
+
+patches:
+  # The chart hardcodes its volumeClaimTemplate with no storageClassName knob and the
+  # cluster has no default StorageClass — without this the PVC never binds (pod Pending).
+  - target:
+      kind: StatefulSet
+      name: openshell
+    patch: |-
+      - op: add
+        path: /spec/volumeClaimTemplates/0/spec/storageClassName
+        value: zfs-nvme


### PR DESCRIPTION
## Summary

Follow-up to #839: the OpenShell pod is stuck Pending because its PVC never binds — the chart hardcodes the `volumeClaimTemplate` with no `storageClassName` knob, and the bastion cluster has **no default StorageClass** (`local` and `zfs-nvme` exist, neither default).

Adds a kustomize JSON patch setting `storageClassName: zfs-nvme` (the repo convention, 38 existing uses) on the StatefulSet's volume claim template. Render verified.

### Post-merge note
`volumeClaimTemplates` are immutable — the existing StatefulSet and its Pending PVC will be deleted so ArgoCD recreates them with the patched template (no data loss; the PVC never bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)