### PR TITLE
feat(agentic-ai): AppProject destinations for phase 3 experiment namespaces (wave 1)

### DIFF
--- a/kubernetes/argocd/projects/admin.yaml
+++ b/kubernetes/argocd/projects/admin.yaml
@@ -36,6 +36,9 @@ spec:
     - namespace: 'tailscale'
       name: '*'
       server: '*'
+    - namespace: 'dex'
+      name: '*'
+      server: '*'
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/kubernetes/argocd/projects/agentic-ai.yaml
+++ b/kubernetes/argocd/projects/agentic-ai.yaml
@@ -24,6 +24,12 @@ spec:
     - name: "*"
       namespace: openshell-track-reference
       server: "*"
+    - name: "*"
+      namespace: openshell-hermes
+      server: "*"
+    - name: "*"
+      namespace: kagent
+      server: "*"
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'


### PR DESCRIPTION
## Summary

Phase 3 (agentic-ai workstream) wave 1 gating change: register the three namespaces that wave 2 overlay PRs will deploy into. ArgoCD AppProject destinations must exist in git before the ApplicationSet apps can sync (research pitfall 5).

- `agentic-ai` AppProject: add `openshell-hermes` (Hermes Agent experiment track, plan 03-04) and `kagent` (kagent gate experiment, plan 03-03) destinations
- `admin` AppProject: add `dex` destination (standalone Dex OIDC issuer, plan 03-09 — cluster-level identity infra per 2026-06-10 decision)

Additive only — existing destinations, whitelists, and sourceRepos untouched.

## Verification

- `grep` confirms all five pre-existing agentic-ai destinations still present
- Both files parse as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
