### PR TITLE
[codex] Add Gamarr media app overlay

### DIFF
--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/deployment.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gamarr
+  labels:
+    app.kubernetes.io/name: gamarr
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gamarr
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gamarr
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: gamarr
+          image: ghcr.io/jeremiahm37/gamarr:v1.2.0@sha256:0833d25493f551c3e411e249feeb0e20287d2148e154fda6561bff99eb6a7a64
+          ports:
+            - containerPort: 5001
+              name: http
+          env:
+            - name: GAMARR_PORT
+              value: "5001"
+            - name: DATA_DIR
+              value: /data/gamarr
+            - name: METRICS_ENABLED
+              value: "true"
+            - name: PROWLARR_URL
+              value: http://prowlarr.media.svc.cluster.local:9696
+            - name: SABNZBD_URL
+              value: http://sabnzbd.media.svc.cluster.local:8080
+            - name: SABNZBD_CATEGORY
+              value: games
+            - name: QB_SAVE_PATH
+              value: /media/downloads/games
+            - name: WATCHER_ENABLED
+              value: "false"
+            - name: GAMES_VAULT_PATH
+              value: /media/games/vault
+            - name: GAMES_ROMS_PATH
+              value: /media/games/roms
+            - name: EXTRACT_ARCHIVES
+              value: "false"
+            - name: TZ
+              value: America/Chicago
+          envFrom:
+            - secretRef:
+                name: gamarr-secret
+          volumeMounts:
+            - name: data
+              mountPath: /data/gamarr
+            - name: media
+              mountPath: /media
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 5001
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 5001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: gamarr-config
+        - name: media
+          persistentVolumeClaim:
+            claimName: purplebox-nfs-media
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gamarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: gamarr-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AUTH_USERNAME: "{{ .AUTH_USERNAME }}"
+        AUTH_PASSWORD: "{{ .AUTH_PASSWORD }}"
+        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+        SABNZBD_API_KEY: "{{ .SABNZBD_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: gamarr
+    - extract:
+        key: prowlarr
+    - extract:
+        key: sabnzbd

--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/ingress.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gamarr
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - gamarr
+  rules:
+    - host: gamarr
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gamarr
+                port:
+                  number: 5001

--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - persistence.yaml
+  - externalsecret.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/persistence.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/persistence.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gamarr-restic
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: gamarr-restic-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/gamarr"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-restic-template
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gamarr-config
+spec:
+  accessModes: ["ReadWriteOnce"]
+  dataSourceRef:
+    kind: ReplicationDestination
+    apiGroup: volsync.backube
+    name: gamarr-config-rdst
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: zfs-nvme
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: gamarr-config-rdst
+spec:
+  trigger:
+    manual: restore-zfs-snapshot
+  restic:
+    repository: gamarr-restic-secret
+    copyMethod: Snapshot
+    accessModes: ["ReadWriteOnce"]
+    storageClassName: zfs-nvme
+    cacheStorageClassName: zfs-nvme
+    volumeSnapshotClassName: zfs-nvme-snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    capacity: 2Gi
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: gamarr-config-rsrc
+spec:
+  sourcePVC: gamarr-config
+  trigger:
+    schedule: "45 */8 * * *"
+  restic:
+    pruneIntervalDays: 7
+    repository: gamarr-restic-secret
+    copyMethod: Snapshot
+    accessModes: ["ReadWriteOnce"]
+    storageClassName: zfs-nvme
+    cacheStorageClassName: zfs-nvme
+    volumeSnapshotClassName: zfs-nvme-snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    retain:
+      hourly: 24
+      daily: 7
+      weekly: 5

--- a/kubernetes/deploy/home/media/gamarr/clusters/bastion/service.yaml
+++ b/kubernetes/deploy/home/media/gamarr/clusters/bastion/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gamarr
+  labels:
+    app.kubernetes.io/name: gamarr
+spec:
+  selector:
+    app.kubernetes.io/name: gamarr
+  ports:
+    - port: 5001
+      targetPort: 5001
+      name: http
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Adds a raw Kustomize overlay for Gamarr in the Bastion `media` namespace alongside the existing media services.

## Changes

- Deploys `ghcr.io/jeremiahm37/gamarr:v1.2.0@sha256:0833d25493f551c3e411e249feeb0e20287d2148e154fda6561bff99eb6a7a64` as a non-root Deployment on port `5001`.
- Adds ClusterIP Service and Tailscale Ingress host `gamarr`.
- Wires Gamarr to in-cluster Prowlarr and SABnzbd service URLs.
- Mounts `purplebox-nfs-media` at `/media` for `/media/games/vault`, `/media/games/roms`, and SABnzbd-visible download paths.
- Adds `gamarr-config` PVC plus VolSync/restic backup resources.
- Adds ExternalSecrets for `gamarr-secret` and `gamarr-restic-secret`.

## Rollout prerequisite

Before Argo sync can make the pod Ready, create or verify the 1Password item `gamarr` in vault `jtcressy-net-infra` with fields:

- `AUTH_USERNAME`
- `AUTH_PASSWORD`

I could not create or verify that item from this session because `op signin` could not connect to the local 1Password desktop app.

## Validation

- `task apps:overlays:render project=home namespace=media app=gamarr cluster=bastion`
- `yq e 'select(.kind != null) | .kind + "/" + .metadata.name' /tmp/gamarr-render.yaml`
- `kubectl apply --dry-run=server -n media -f /tmp/gamarr-render.yaml`
- `kubectl get svc -n media prowlarr sabnzbd`
- `kubectl get pvc -n media purplebox-nfs-media`
- `kubectl get externalsecret -n media prowlarr sabnzbd`
- `crane digest ghcr.io/jeremiahm37/gamarr:v1.2.0`
- `git diff --cached --check`