### PR TITLE
fix(hermes): run gateway subcommand instead of interactive CLI

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
@@ -55,6 +55,11 @@ spec:
         - name: hermes
           image: nousresearch/hermes-agent:v2026.7.1@sha256:b6c019227889e6675424a2b6223b2cafdd36bf7d1048d1ddd8e043b880d6cc0f
           imagePullPolicy: IfNotPresent
+          # Pass the gateway subcommand as the container CMD; the image
+          # entrypoint (/init + main-wrapper.sh) turns this into
+          # `hermes gateway run`. Without it the wrapper launches the
+          # interactive CLI, which exits immediately on a non-TTY stdin.
+          args: ["gateway", "run"]
           env:
             - name: HERMES_UID
               value: "10000"


### PR DESCRIPTION
The deployed Hermes container had no `command`/`args`, so the image entrypoint launched the interactive `hermes` CLI. On a non-TTY stdin it prints `Goodbye!` and exits → CrashLoopBackOff (observed on the live pod after #882 deployed).

Fix: pass `args: ["gateway", "run"]` so the s6 wrapper runs `hermes gateway run`, matching upstream `docker-compose.yml`. Entrypoint (`/init` + `main-wrapper.sh`) unchanged.

Validated: `kustomize build --enable-helm` on the overlay passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4RBmPiCcHZz4iBmFwhcGQ