### PR TITLE
fix(hermes): enable dashboard via container env, not just .env

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
@@ -63,6 +63,15 @@ spec:
           env:
             - name: HERMES_UID
               value: "10000"
+            # The dashboard runs as a separate s6 `with-contenv` service whose
+            # run/finish scripts gate on HERMES_DASHBOARD from the shell env —
+            # NOT from /opt/data/.env (that file is read only by the Python
+            # process). Without this as a real container env var the wrapper
+            # treats the dashboard as disabled: run exits immediately and
+            # finish exits 125, so s6 marks it permanently down and 9119 never
+            # binds (ingress → 502). Keep it here, not only in the ESO .env.
+            - name: HERMES_DASHBOARD
+              value: "1"
           ports:
             - name: api
               containerPort: 8642


### PR DESCRIPTION
## Symptom
Tailscale ingress to `https://hermes.tailnet-4d89.ts.net` returns **502** — the dashboard never binds port 9119.

## Root cause
The dashboard is a separate s6 `#!/command/with-contenv` service. Its `run` and `finish` scripts gate on `HERMES_DASHBOARD` **from the shell environment**. We set `HERMES_DASHBOARD=1` only in the ESO-rendered `/opt/data/.env`, which is loaded by the Python process — **not** by the s6 shell wrappers. So the wrapper saw it unset: `run` exited immediately (dashboard treated as disabled) and `finish` exited 125, which tells s6-supervise to mark the service **permanently down**. 9119 never listened.

Diagnosis confirmed live: injecting `HERMES_DASHBOARD=1` into `/run/s6/container_environment` and `s6-svc -u` brought the service up and 9119 began listening immediately.

## Fix
Set `HERMES_DASHBOARD=1` as a real container env var so s6 populates it into `container_environment` and the `with-contenv` wrapper launches the dashboard. OIDC/auth config stays in `.env` (the Python `hermes dashboard` process reads it).

Validated: `kustomize build --enable-helm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4RBmPiCcHZz4iBmFwhcGQ