### PR TITLE
feat(hermes): restrict Discord bot to allowlisted user

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
@@ -25,6 +25,7 @@ spec:
           API_SERVER_PORT=8642
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           DISCORD_BOT_TOKEN={{ .DISCORD_BOT_TOKEN }}
+          DISCORD_ALLOWED_USERS={{ .DISCORD_ALLOWED_USERS }}
           OPENAI_API_KEY={{ .OPENAI_API_KEY }}
           HERMES_DASHBOARD=1
           HERMES_DASHBOARD_PUBLIC_URL=https://hermes.tailnet-4d89.ts.net


### PR DESCRIPTION
Adds `DISCORD_ALLOWED_USERS` to the rendered `.env` (sourced from the `hermes` 1Password item) so the gateway only answers the owner's Discord user ID instead of every user it can see.

Value lives in 1Password (not committed). Validated: `kustomize build --enable-helm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4RBmPiCcHZz4iBmFwhcGQ