### PR TITLE
feat(hermes): add METAMCP_API_KEY for MetaMCP MCP server

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
@@ -37,6 +37,7 @@ spec:
           HERMES_DASHBOARD_OIDC_CLIENT_SECRET={{ .HERMES_DASHBOARD_OIDC_CLIENT_SECRET }}
           CAMOFOX_URL=http://hermes-camofox.hermes.svc:9377
           CAMOFOX_API_KEY={{ .CAMOFOX_API_KEY }}
+          METAMCP_API_KEY={{ .METAMCP_API_KEY }}
   dataFrom:
     - extract:
         key: hermes


### PR DESCRIPTION
Renders `METAMCP_API_KEY` into the gateway `.env` (from the `hermes` 1Password item) so `config.yaml` can reference `${METAMCP_API_KEY}` in the `mcp_servers.metamcp-obsidian` bearer header. Headless deployment uses an API key rather than the interactive OAuth flow.

Value in 1Password (not committed). Validated: `kustomize build --enable-helm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4RBmPiCcHZz4iBmFwhcGQ