### PR TITLE
Add mem0 pgvector backend for Hermes memory

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/kustomization.yaml
@@ -13,3 +13,7 @@ resources:
   - ingress.yaml
   - netpol.yaml
   - camofox.yaml
+  # mem0 self-hosted memory backend: dedicated CNPG Postgres + pgvector.
+  - pg-r2-externalsecret.yaml
+  - pg-cluster.yaml
+  - pg-backup.yaml

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-backup.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-backup.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: hermes-db-backup
+spec:
+  schedule: "7 0 0 * * *"
+  immediate: true
+  suspend: false
+  cluster:
+    name: hermes-db

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
@@ -1,0 +1,42 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: hermes-db
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie
+  storage:
+    size: 10Gi
+    storageClass: zfs-nvme
+  monitoring:
+    enablePodMonitor: true
+  nodeMaintenanceWindow:
+    reusePVC: true
+  # mem0 (self-hosted OSS) stores its fact vectors here. The application
+  # database `mem0` is owned by the `mem0` role; CNPG surfaces its credentials
+  # in the generated `hermes-db-app` secret. pgvector (0.8.1, shipped in the
+  # -system- image) is enabled at bootstrap as superuser in the app database.
+  bootstrap:
+    initdb:
+      database: mem0
+      owner: mem0
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://restic-backups/hermes/
+      endpointURL: https://5d4249bf326be62396b18a9f6000341b.r2.cloudflarestorage.com
+      s3Credentials:
+        accessKeyId:
+          name: hermes-cnpg-r2-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: hermes-cnpg-r2-secret
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+        encryption: AES256
+      data:
+        compression: gzip
+        encryption: AES256
+    retentionPolicy: "7d"

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-r2-externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-r2-externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-cnpg-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: hermes-cnpg-r2-secret
+    creationPolicy: Owner
+  # Shared homelab R2 backup credentials (1Password item `cloudflare-r2-generic`).
+  # The token is scoped to the `restic-backups` bucket; hermes backs up under the
+  # `hermes/` prefix, matching the per-app convention used by dograh, teslamate, etc.
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: access_key_id
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: cloudflare-r2-generic
+        property: secret_access_key


### PR DESCRIPTION
## What

Dedicated CloudNativePG cluster (`hermes-db`) as the self-hosted **mem0 OSS** memory backend for the Hermes agent.

- **CNPG cluster** on `ghcr.io/cloudnative-pg/postgresql:17.6-system-trixie` (ships pgvector 0.8.1). Bootstraps the `mem0` database with `CREATE EXTENSION vector` via `postInitApplicationSQL`.
- **R2 backups** to the shared `restic-backups` bucket under the `hermes/` prefix, reusing `cloudflare-r2-generic` creds via ESO — same convention as dograh/teslamate. Token is bucket-scoped; prefix isolation only.
- **Daily ScheduledBackup**.

## Why

Replaces the rejected always-inject memory approaches (Honcho) with mem0's bounded, `top_k`+rerank semantic recall. Embedder (`mxbai-embed-large`, 1024-dim) and extraction LLM (`qwen2.5:3b`) are served by the existing `ollama-purplebox` host (192.168.20.249); reachability from the Hermes pod verified (HTTP 200, ~80ms).

## Follow-up (not in this PR)

mem0 itself is wired on the Hermes PVC via `hermes memory setup mem0 --mode oss` (pgvector + ollama), pointing at `hermes-db-rw` and the CNPG-generated `hermes-db-app` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)