### PR TITLE
Activate mem0 memory backend in Hermes gateway

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
@@ -72,6 +72,17 @@ spec:
             # binds (ingress → 502). Keep it here, not only in the ESO .env.
             - name: HERMES_DASHBOARD
               value: "1"
+            # mem0 self-hosted memory backend runs from PVC-installed deps
+            # (mem0ai/psycopg2/ollama under /opt/data/pydeps, installed out of
+            # band via `uv pip install --target`). PYTHONPATH lets the gateway's
+            # Python import them. The deps and $HERMES_HOME/mem0.json are
+            # PVC-resident runtime state, not baked into the image.
+            - name: PYTHONPATH
+              value: /opt/data/pydeps
+            # mem0ai phones home to PostHog by default; disable it so nothing
+            # about memory contents or usage leaves the network.
+            - name: MEM0_TELEMETRY
+              value: "False"
           ports:
             - name: api
               containerPort: 8642


### PR DESCRIPTION
## What

Runtime env so the Hermes gateway loads the self-hosted **mem0** provider (`memory.provider=mem0`):

- `PYTHONPATH=/opt/data/pydeps` — gateway Python imports the PVC-installed `mem0ai`/`psycopg2`/`ollama` deps.
- `MEM0_TELEMETRY=False` — disables mem0ai's default PostHog telemetry (nothing leaves the network).

## Verified

- `plugins.memory.load_memory_provider("mem0")` → `Mem0MemoryProvider`, `is_available()=True` (exact gateway activation path).
- Standalone roundtrip: OpenRouter extraction 6.7s, local mxbai embed + pgvector recall 0.2s, correct fact returned.
- Backend: `hermes-db` CNPG cluster (#889), pgvector 0.8.1, `mem0` table created.
- Embedder/LLM: `mxbai-embed-large` (local Ollama, 1024-dim) + `openai/gpt-4o-mini` via OpenRouter (temporary, until GPU passthrough lets qwen2.5:3b run local).

## Notes

mem0 deps (`/opt/data/pydeps`) and `mem0.json` are PVC-resident runtime state, not baked into the image. A follow-up may bake them into a custom image for full reconstructability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)