### PR TITLE
hermes: source mem0 deps from image volume, not PVC

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
@@ -72,13 +72,16 @@ spec:
             # binds (ingress → 502). Keep it here, not only in the ESO .env.
             - name: HERMES_DASHBOARD
               value: "1"
-            # mem0 self-hosted memory backend runs from PVC-installed deps
-            # (mem0ai/psycopg2/ollama under /opt/data/pydeps, installed out of
-            # band via `uv pip install --target`). PYTHONPATH lets the gateway's
-            # Python import them. The deps and $HERMES_HOME/mem0.json are
-            # PVC-resident runtime state, not baked into the image.
+            # mem0 self-hosted memory backend runs from deps
+            # (mem0ai/psycopg2/ollama) delivered by the read-only `mem0-deps`
+            # image volume mounted at /opt/mem0-deps (built by
+            # ghcr.io/jtcressy/hermes-mem0-deps). PYTHONPATH lets the gateway's
+            # Python import them. This replaces the former PVC-resident install
+            # at /opt/data/pydeps so the deps are durable and reproducible from
+            # Git. Only $HERMES_HOME/mem0.json remains PVC-resident runtime
+            # state; the deps are no longer baked into or written to the PVC.
             - name: PYTHONPATH
-              value: /opt/data/pydeps
+              value: /opt/mem0-deps
             # mem0ai phones home to PostHog by default; disable it so nothing
             # about memory contents or usage leaves the network.
             - name: MEM0_TELEMETRY
@@ -91,6 +94,12 @@ spec:
           volumeMounts:
             - name: hermes-data
               mountPath: /opt/data
+            # Read-only image volume carrying the mem0 Python deps. Mounted
+            # outside /opt/data because an image volume cannot overlay a
+            # subdirectory of the RWO PVC mounted there.
+            - name: mem0-deps
+              mountPath: /opt/mem0-deps
+              readOnly: true
           # TCP-only: the exact HTTP health path on 8642 isn't confirmed
           # upstream, but API_SERVER_ENABLED=true + API_SERVER_HOST=0.0.0.0
           # (set in the rendered .env) guarantee the port binds beyond
@@ -115,6 +124,16 @@ spec:
         - name: hermes-data
           persistentVolumeClaim:
             claimName: hermes-data
+        # Durable, reproducible mem0 deps delivered as a Kubernetes image
+        # volume (beta-default on k8s 1.34 / containerd 2.1). Built by the
+        # containers repo (ghcr.io/jtcressy/hermes-mem0-deps).
+        # TODO: pin to @sha256 digest after the first publish. This rolling
+        # tag is a placeholder because the image is not built until the
+        # containers PR merges and CI publishes it.
+        - name: mem0-deps
+          image:
+            reference: ghcr.io/jtcressy/hermes-mem0-deps:rolling
+            pullPolicy: IfNotPresent
         - name: hermes-env
           secret:
             secretName: hermes-env

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/deployment.yaml
@@ -126,13 +126,11 @@ spec:
             claimName: hermes-data
         # Durable, reproducible mem0 deps delivered as a Kubernetes image
         # volume (beta-default on k8s 1.34 / containerd 2.1). Built by the
-        # containers repo (ghcr.io/jtcressy/hermes-mem0-deps).
-        # TODO: pin to @sha256 digest after the first publish. This rolling
-        # tag is a placeholder because the image is not built until the
-        # containers PR merges and CI publishes it.
+        # containers repo (ghcr.io/jtcressy/hermes-mem0-deps). Digest-pinned to
+        # the first published `rolling` build; Renovate bumps the digest.
         - name: mem0-deps
           image:
-            reference: ghcr.io/jtcressy/hermes-mem0-deps:rolling
+            reference: ghcr.io/jtcressy/hermes-mem0-deps:rolling@sha256:f75febc9c9d67ea359d72ff4ba264902ba75fcd021ba845cddadb2cce42367e2
             pullPolicy: IfNotPresent
         - name: hermes-env
           secret:


### PR DESCRIPTION
## What

Replaces the fragile PVC-resident mem0 dependency install with a durable, reproducible Kubernetes `image` volume in the Hermes bastion deployment.

- Adds a read-only `mem0-deps` `image` volume referencing `ghcr.io/jtcressy/hermes-mem0-deps`, mounted at `/opt/mem0-deps` (outside the `/opt/data` PVC mount — an image volume cannot overlay a PVC subdir).
- Changes container `PYTHONPATH` from `/opt/data/pydeps` to `/opt/mem0-deps`.
- Updates the explanatory comment to reflect the new source.

No change to the upstream `nousresearch/hermes-agent` image; `mem0.json` and secrets untouched.

## Why

The mem0 deps (`mem0ai`/`psycopg2-binary`/`ollama`) currently live on the RWO `hermes-data` PVC at `/opt/data/pydeps`, installed out of band via `uv pip install --target`. They're lost on PVC recreation and not reproducible from Git. The image volume (beta-default on this cluster: k8s 1.34.1, containerd 2.1.5) makes them durable and reproducible without forking the full Hermes image.

## Two-phase ordering (publish then digest-pin)

The deps image does not exist yet, so this PR references it by the rolling tag as a placeholder with a `# TODO: pin to @sha256 digest` marker. Required merge order:

1. Merge the containers PR (jtcressy/containers#4) → CI publishes `ghcr.io/jtcressy/hermes-mem0-deps`.
2. Update this PR to swap the rolling tag for the published `@sha256` digest.
3. Merge this PR.

## Validation

`kubectl kustomize .` in `clusters/bastion/` renders cleanly (namespace applied by the ApplicationSet transformer, so none is set locally).

## Caveat

Python-version coupling: if upstream Hermes bumps its interpreter off Python 3.13, the deps image must be rebuilt against the new version (compiled wheels are interpreter-specific) before updating the reference here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)