### PR TITLE
Add dograh-hermes-adapter deployment (bridge to Hermes agent)

### DIFF
--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/configmap.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/configmap.yaml
@@ -1,0 +1,15 @@
+---
+# CALLER_WHITELIST maps normalized E.164 caller numbers to stable Hermes
+# session keys. Seeded empty: unknown callers fall back to their own
+# normalized number, so an empty map still gives every caller an isolated
+# memory scope.
+# TODO: swap to ExternalSecret from 1P item 'hermes-caller-whitelist' once curated
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dograh-hermes-adapter-config
+  labels:
+    app.kubernetes.io/name: dograh-hermes-adapter
+    app.kubernetes.io/part-of: dograh
+data:
+  CALLER_WHITELIST: "{}"

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dograh-hermes-adapter
+  labels:
+    app.kubernetes.io/name: dograh-hermes-adapter
+    app.kubernetes.io/part-of: dograh
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dograh-hermes-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dograh-hermes-adapter
+        app.kubernetes.io/part-of: dograh
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - name: adapter
+          # TODO: pin to @sha256 digest after first publish
+          image: ghcr.io/jtcressy/dograh-hermes-adapter:main
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: HERMES_BASE_URL
+              value: http://hermes.hermes.svc.cluster.local:8642
+            - name: HERMES_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dograh-hermes-adapter-secret
+                  key: HERMES_API_KEY
+            - name: CALLER_WHITELIST
+              valueFrom:
+                configMapKeyRef:
+                  name: dograh-hermes-adapter-config
+                  key: CALLER_WHITELIST
+            - name: REQUEST_TIMEOUT_SECONDS
+              value: "60"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
@@ -20,8 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: adapter
-          # TODO: pin to @sha256 digest after first publish
-          image: ghcr.io/jtcressy/dograh-hermes-adapter:main
+          image: ghcr.io/jtcressy/dograh-hermes-adapter:sha-407e451@sha256:70cdb734244407881b481beb0821b5ffd30cbcd38fa1180d176d1b954ec93b97
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# Pulls the Hermes API server key from the same 1Password item Hermes itself
+# reads (item "hermes", field API_SERVER_KEY) so the adapter authenticates to
+# Hermes' OpenAI-compatible API with the exact key Hermes expects.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-hermes-adapter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-hermes-adapter-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        HERMES_API_KEY: "{{ .API_SERVER_KEY }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dograh
+resources:
+  - externalsecret.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/service.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dograh-hermes-adapter
+  labels:
+    app.kubernetes.io/name: dograh-hermes-adapter
+    app.kubernetes.io/part-of: dograh
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dograh-hermes-adapter
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ingress
   - asterisk
   - jellyseerr-adapter
+  - hermes-adapter
   - backups


### PR DESCRIPTION
## What

Adds the `dograh-hermes-adapter` service to the bastion `dograh` overlay. It bridges the Dograh voice platform to the Hermes agent's OpenAI-compatible API.

Dograh's built-in HTTP tool can only send a flat JSON body with static headers — it can't build an OpenAI `messages[]` array or set a per-call header. The adapter accepts flat fields (`caller_number`, `call_id`, `question`) on `POST /ask` and translates them into a correct Hermes `POST /v1/chat/completions` call, injecting:

- `Authorization: Bearer {HERMES_API_KEY}`
- `X-Hermes-Session-Key: {user_id}` — stable per-caller memory scope
- `X-Hermes-Session-Id: {call_id}` — per-call conversation scope

Adapter source + image: https://github.com/jtcressy/dograh-hermes-adapter (private). Mirrors the sibling `jellyseerr-adapter` structure exactly.

## Manifests

New `hermes-adapter/` dir mirroring `jellyseerr-adapter/`:

- `deployment.yaml` — port 8080, `/health` probes, hardened securityContext, resource caps.
- `service.yaml` — ClusterIP on 8080.
- `externalsecret.yaml` — sources `HERMES_API_KEY` from the same 1Password item Hermes itself reads (item `hermes`, field `API_SERVER_KEY`) via the `onepassword` ClusterSecretStore, so the adapter authenticates with the exact key Hermes expects.
- `configmap.yaml` — `CALLER_WHITELIST` seeded empty (`{}`). Unknown callers fall back to their own normalized number, so an empty map still gives every caller an isolated memory scope. `# TODO: swap to ExternalSecret from 1P item 'hermes-caller-whitelist' once curated`.
- `kustomization.yaml` — namespace `dograh`.

Also adds `hermes-adapter` to the dograh root `kustomization.yaml` resources list (alongside `jellyseerr-adapter`).

Validated: `kubectl kustomize --enable-helm .` at the overlay root renders exit-0. (`--enable-helm` is required by the pre-existing `valkey` Helm inflation, not this change.)

## Two-phase image / digest pin ordering

The image is built and published by the adapter repo's own CI (Deliverable 1), which has already run green:

- Published: `ghcr.io/jtcressy/dograh-hermes-adapter` — tags `main` and `sha-407e451`
- Digest: `sha256:70cdb734244407881b481beb0821b5ffd30cbcd38fa1180d176d1b954ec93b97`

`deployment.yaml` currently references the rolling `:main` tag with a `# TODO: pin to @sha256 digest after first publish` marker. **Phase 2 (follow-up):** pin the image to `ghcr.io/jtcressy/dograh-hermes-adapter:sha-407e451@sha256:70cdb734244407881b481beb0821b5ffd30cbcd38fa1180d176d1b954ec93b97` before merge/deploy, matching the sibling `jellyseerr-adapter` digest-pin convention.

> Note: the adapter repo is private. The cluster needs GHCR package read access (or the package visibility must be changed) before unauthenticated pulls succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
