### PR TITLE
Add GROQ_API_KEY to Hermes .env template

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
@@ -30,6 +30,7 @@ spec:
           DISCORD_BOT_TOKEN={{ .DISCORD_BOT_TOKEN }}
           DISCORD_ALLOWED_USERS={{ .DISCORD_ALLOWED_USERS }}
           OPENAI_API_KEY={{ .OPENAI_API_KEY }}
+          GROQ_API_KEY={{ .GROQ_API_KEY }}
           HERMES_DASHBOARD=1
           HERMES_DASHBOARD_PUBLIC_URL=https://hermes.tailnet-4d89.ts.net
           HERMES_DASHBOARD_OIDC_ISSUER=https://tsidp.tailnet-4d89.ts.net


### PR DESCRIPTION
## Summary
- Adds `GROQ_API_KEY={{ .GROQ_API_KEY }}` to the Hermes ExternalSecret `.env` template.

## Why
Hermes Discord voice join now works (bot role permissions fixed), but the bot cannot transcribe incoming voice: the image ships no local STT engine and the built-in faster-whisper lazy-install fails on an upstream `numpy==2.4.3` pin conflict (`ResolutionImpossible`). With `GROQ_API_KEY` present, Hermes STT auto-detection selects Groq Whisper as the cloud fallback — no config change needed.

The key is already provisioned in the 1Password `hermes` item (vault `jtcressy-net-infra`), so ESO renders it as soon as this merges.

## Post-merge
1. Wait for ESO refresh (1h interval) or bump the `force-sync` annotation on the `hermes` ExternalSecret.
2. `kubectl rollout restart deploy/hermes -n hermes` (seed-env initContainer re-copies .env to the PVC on boot).
3. Test in Discord: `/voice join` and speak — bot should transcribe via Groq Whisper and reply with edge-tts audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)