### PR TITLE
feat(hermes): wire Dograh callback API key and base URL

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
@@ -39,6 +39,8 @@ spec:
           CAMOFOX_URL=http://hermes-camofox.hermes.svc:9377
           CAMOFOX_API_KEY={{ .CAMOFOX_API_KEY }}
           METAMCP_API_KEY={{ .METAMCP_API_KEY }}
+          DOGRAH_API_KEY={{ .DOGRAH_API_KEY }}
+          DOGRAH_API_BASE_URL=http://dograh-api.dograh.svc.cluster.local:8000
   dataFrom:
     - extract:
         key: hermes


### PR DESCRIPTION
## Purpose

Hermes cron jobs place conversational callback calls through Dograh (session continuity via the hermes-adapter `session_id`). This wires the two runtime values the gateway needs to call the Dograh public agent-workflow API:

- `DOGRAH_API_KEY` — extracted from the 1Password item `hermes`, following the `GROQ_API_KEY` precedent set in #893.
- `DOGRAH_API_BASE_URL` — a non-secret literal (`http://dograh-api.dograh.svc.cluster.local:8000`) inlined directly in the ESO v2 template alongside the extracted keys.

Both land in the single `/opt/data/.env` blob that the `seed-env` initContainer writes on pod boot.

## Usage snippet (curl from the Hermes execution backend)

```bash
curl -sS -X POST "$DOGRAH_API_BASE_URL/api/v1/public/agent/workflow/<WORKFLOW_UUID>" \
  -H "X-API-Key: $DOGRAH_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"phone_number": "PJSIP/0003@unifi-talk", "initial_context": {"hermes_session_id": "<session>", "result": "<message>"}}'
```

## Pre-merge checklist

- [ ] User mints a Dograh API key (Dograh UI → `/configurations/api-keys`).
- [ ] User adds field `DOGRAH_API_KEY` to the 1Password item `hermes` (vault `jtcressy-net-infra`).

> **Important:** The 1Password item `hermes` does not yet have a `DOGRAH_API_KEY` field. Until it is added, the ExternalSecret's `dataFrom.extract` will not surface the key. Following the #893 precedent, `DOGRAH_API_KEY={{ .DOGRAH_API_KEY }}` renders the value inline in the `.env` blob and does not affect the other extracted keys — a missing field renders empty for that one line rather than breaking the whole secret. Still, mint and add the key before relying on the callback path.

## NetworkPolicy verification (no change needed)

- The hermes overlay's `netpol.yaml` (`hermes-gw-ingress`) is `policyTypes: [Ingress]` only — egress from the hermes namespace is intentionally unrestricted, so hermes → `dograh-api:8000` outbound is not blocked.
- No NetworkPolicy in `kubernetes/deploy/agentic-ai/dograh/**` restricts ingress to the dograh-api pods. The valkey Helm chart does not enable a NetworkPolicy in its `valuesInline`, and no raw NetworkPolicy manifest exists in the dograh tree. Nothing blocks the hermes → dograh-api path, so no policy was added.

## Validation

`kubectl kustomize` on the touched overlay (`kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/`) builds successfully; both `DOGRAH_API_KEY` and `DOGRAH_API_BASE_URL` render into the `.env` template.

## Post-merge steps

1. Force an ESO refresh (bump the `force-sync` annotation on the ExternalSecret, or wait for the 1h `refreshInterval`).
2. `kubectl rollout restart deployment/hermes -n hermes` — the `seed-env` initContainer rewrites `/opt/data/.env` on pod boot, so a restart is required to pick up the new keys.

## Out of scope

The `dograh-hermes-adapter` image bump for the `session_id` feature lands separately, after that repo's PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
