### PR TITLE
dograh-asterisk: dynamic multi-account SIP provisioning via ESO-rendered config

### DIFF
--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 name: dograh-asterisk-env
           env:
             - name: ASTERISK_REQUIRE_UNIFI
-              value: "true"
+              value: "false"
             - name: ASTERISK_ARI_USERNAME
               value: dograh
             - name: ASTERISK_STASIS_APP
@@ -81,6 +81,9 @@ spec:
             - name: asterisk-templates
               mountPath: /etc/asterisk/templates
               readOnly: true
+            - name: dynamic-config
+              mountPath: /etc/asterisk/dynamic
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -114,7 +117,62 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+        - name: config-reloader
+          image: ghcr.io/jtcressy/docker-asterisk:asterisk-22.9.0@sha256:bf7b44aa79128b82d9a21e8f3bbf1227e507599f1de90c57573245636ba1699e
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -u
+              gen() { readlink /etc/asterisk/dynamic/..data; }
+              reload() {
+                local m
+                for m in res_pjsip.so res_pjsip_endpoint_identifier_ip.so res_pjsip_outbound_registration.so pbx_config.so; do
+                  curl -sf -X PUT -u "${ASTERISK_ARI_USERNAME}:${ASTERISK_ARI_PASSWORD}" \
+                    "http://127.0.0.1:8088/ari/asterisk/modules/${m}" || return 1
+                done
+              }
+              prev="$(gen)"
+              echo "config-reloader watching generation ${prev}"
+              while sleep 10; do
+                cur="$(gen)"
+                if [ "${cur}" != "${prev}" ]; then
+                  if reload; then
+                    prev="${cur}"
+                    echo "reloaded modules for generation ${cur}"
+                  else
+                    echo "reload failed for generation ${cur}; will retry" >&2
+                  fi
+                fi
+              done
+          env:
+            - name: ASTERISK_ARI_USERNAME
+              value: dograh
+          envFrom:
+            - secretRef:
+                name: dograh-asterisk-env
+          volumeMounts:
+            - name: dynamic-config
+              mountPath: /etc/asterisk/dynamic
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
       volumes:
         - name: asterisk-templates
           configMap:
             name: dograh-asterisk-templates
+        - name: dynamic-config
+          secret:
+            secretName: dograh-asterisk-dynamic

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
@@ -20,3 +20,93 @@ spec:
   dataFrom:
     - extract:
         key: dograh
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dograh-asterisk-dynamic
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dograh-asterisk-dynamic
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        pjsip-endpoints.conf: |
+          {{- $accounts := .unifi_talk_accounts | mustFromJson }}
+          {{- if eq (len $accounts) 0 }}{{ fail "unifi_talk_accounts is empty" }}{{- end }}
+          {{- range $a := $accounts }}
+          [unifi-talk-{{ $a.extension }}-auth]
+          type = auth
+          auth_type = userpass
+          username = {{ $a.username }}
+          password = {{ $a.password }}
+
+          [unifi-talk-{{ $a.extension }}-aor]
+          type = aor
+          contact = sip:{{ $a.server }}:{{ $a.port }}
+          qualify_frequency = 30
+
+          [unifi-talk-{{ $a.extension }}]
+          type = endpoint
+          transport = transport-udp
+          context = from-unifi-talk-{{ $a.extension }}
+          disallow = all
+          allow = ulaw
+          aors = unifi-talk-{{ $a.extension }}-aor
+          outbound_auth = unifi-talk-{{ $a.extension }}-auth
+          from_user = {{ $a.username }}
+          from_domain = {{ $a.server }}
+          rewrite_contact = yes
+          rtp_symmetric = yes
+          force_rport = yes
+          direct_media = no
+          trust_id_inbound = yes
+          send_rpid = yes
+
+          [unifi-talk-{{ $a.extension }}-registration]
+          type = registration
+          transport = transport-udp
+          outbound_auth = unifi-talk-{{ $a.extension }}-auth
+          server_uri = sip:{{ $a.server }}:{{ $a.port }}
+          client_uri = sip:{{ $a.username }}@{{ $a.server }}:{{ $a.port }}
+          contact_user = {{ $a.username }}
+          retry_interval = 60
+          forbidden_retry_interval = 600
+          expiration = 3600
+          line = yes
+          endpoint = unifi-talk-{{ $a.extension }}
+
+          [unifi-talk-{{ $a.extension }}-identify]
+          type = identify
+          endpoint = unifi-talk-{{ $a.extension }}
+          match = {{ $a.server }}
+          match_header = To: /sip:{{ $a.username }}@/
+          {{- end }}
+        extensions-inbound.conf: |
+          {{- $accounts := .unifi_talk_accounts | mustFromJson }}
+          {{- if eq (len $accounts) 0 }}{{ fail "unifi_talk_accounts is empty" }}{{- end }}
+          {{- range $a := $accounts }}
+          [from-unifi-talk-{{ $a.extension }}]
+          exten => {{ $a.extension }},1,NoOp(UniFi Talk inbound -> ext {{ $a.extension }})
+           same => n,Stasis(dograh)
+           same => n,Hangup()
+          exten => s,1,Goto({{ $a.extension }},1)
+          exten => _[0-9a-zA-Z+*#].,1,Goto({{ $a.extension }},1)
+          {{- end }}
+          {{- range $a := $accounts }}
+          {{- if $a.primary }}
+
+          [from-dograh]
+          exten => _X.,1,NoOp(Dograh outbound call to ${EXTEN} through UniFi Talk)
+           same => n,Dial(PJSIP/${EXTEN}@unifi-talk-{{ $a.extension }},60)
+           same => n,Hangup()
+          {{- end }}
+          {{- end }}
+  dataFrom:
+    - extract:
+        key: dograh

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/templates/extensions.conf.template
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/templates/extensions.conf.template
@@ -5,23 +5,5 @@ clearglobalvars = no
 
 [globals]
 DOGRAH_STASIS_APP = ${ASTERISK_STASIS_APP}
-UNIFI_TALK_ENDPOINT = ${UNIFI_TALK_ENDPOINT}
 
-[${UNIFI_TALK_INBOUND_CONTEXT}]
-exten => ${DOGRAH_INBOUND_EXTENSION},1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN})
- same => n,Stasis(${ASTERISK_STASIS_APP})
- same => n,Hangup()
-
-exten => s,1,NoOp(UniFi Talk inbound call for Dograh normalizing to ${DOGRAH_INBOUND_EXTENSION})
- same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
-
-exten => _X.,1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN} normalizing to ${DOGRAH_INBOUND_EXTENSION})
- same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
-
-exten => _+X.,1,NoOp(UniFi Talk inbound call for Dograh on ${EXTEN} normalizing to ${DOGRAH_INBOUND_EXTENSION})
- same => n,Goto(${DOGRAH_INBOUND_EXTENSION},1)
-
-[${UNIFI_TALK_OUTBOUND_CONTEXT}]
-exten => _X.,1,NoOp(Dograh outbound call to ${EXTEN} through UniFi Talk)
- same => n,Dial(PJSIP/${EXTEN}@${UNIFI_TALK_ENDPOINT},60)
- same => n,Hangup()
+#include "dynamic/extensions-inbound.conf"

--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/templates/pjsip.conf.template
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/templates/pjsip.conf.template
@@ -1,54 +1,11 @@
 [global]
 type = global
 user_agent = Dograh Asterisk Sidecar
+endpoint_identifier_order = ip,header,username,anonymous
 
 [transport-udp]
 type = transport
 protocol = udp
 bind = ${ASTERISK_PJSIP_BINDADDR}:${ASTERISK_PJSIP_PORT}
 
-[${UNIFI_TALK_ENDPOINT}-auth]
-type = auth
-auth_type = userpass
-username = ${UNIFI_TALK_SIP_USERNAME}
-password = ${UNIFI_TALK_SIP_PASSWORD}
-
-[${UNIFI_TALK_ENDPOINT}-aor]
-type = aor
-contact = sip:${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
-qualify_frequency = 30
-
-[${UNIFI_TALK_ENDPOINT}]
-type = endpoint
-transport = transport-udp
-context = ${UNIFI_TALK_INBOUND_CONTEXT}
-disallow = all
-allow = ulaw
-aors = ${UNIFI_TALK_ENDPOINT}-aor
-outbound_auth = ${UNIFI_TALK_ENDPOINT}-auth
-from_user = ${UNIFI_TALK_SIP_USERNAME}
-from_domain = ${UNIFI_TALK_SIP_SERVER}
-rewrite_contact = yes
-rtp_symmetric = yes
-force_rport = yes
-direct_media = no
-trust_id_inbound = yes
-send_rpid = yes
-
-[${UNIFI_TALK_ENDPOINT}-registration]
-type = registration
-transport = transport-udp
-outbound_auth = ${UNIFI_TALK_ENDPOINT}-auth
-server_uri = sip:${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
-client_uri = sip:${UNIFI_TALK_SIP_USERNAME}@${UNIFI_TALK_SIP_SERVER}:${UNIFI_TALK_SIP_PORT}
-contact_user = ${UNIFI_TALK_SIP_USERNAME}
-retry_interval = 60
-forbidden_retry_interval = 600
-expiration = 3600
-line = yes
-endpoint = ${UNIFI_TALK_ENDPOINT}
-
-[${UNIFI_TALK_ENDPOINT}-identify]
-type = identify
-endpoint = ${UNIFI_TALK_ENDPOINT}
-match = ${UNIFI_TALK_SIP_SERVER}
+#include "dynamic/pjsip-endpoints.conf"


### PR DESCRIPTION
## What

Makes adding an inbound UniFi Talk phone line a **data edit** instead of a config/deploy chore. Per-account pjsip endpoints + dialplan are rendered from a `unifi_talk_accounts` JSON array in the 1Password `dograh` item, through an **ESO v2 template**, into a directory-mounted Secret. A tiny `config-reloader` sidecar polls the Secret generation and hot-reloads Asterisk over ARI — **no pod restart, no image rebuild, no controller.**

**Model:** Dograh = control plane (extension → workflow). 1Password = credential vault. Asterisk = reconciled data plane. The **extension number is the join key**, matched by hand between the Dograh phone-number entry and the 1P cred block.

## Changes (all under `.../clusters/bastion/asterisk/`)

- **`externalsecret.yaml`** — new `dograh-asterisk-dynamic` ExternalSecret rendering `pjsip-endpoints.conf` + `extensions-inbound.conf`. `mustFromJson` + fail-on-empty so a malformed 1P edit **errors and retains the last-good Secret** rather than deregistering live lines. Existing `dograh-asterisk` ES untouched.
- **`templates/pjsip.conf.template`** — static `[global]` (adds `endpoint_identifier_order = ip,header,username,anonymous`) + `[transport-udp]` + `#include "dynamic/pjsip-endpoints.conf"`. Single hard-coded endpoint block removed.
- **`templates/extensions.conf.template`** — static `[general]`/`[globals]` + `#include "dynamic/extensions-inbound.conf"`. Static inbound/outbound contexts removed (outbound now renders for the `primary` account).
- **`deployment.yaml`** — `ASTERISK_REQUIRE_UNIFI="false"`; directory-mounted (non-subPath) `dynamic-config` Secret volume on the main container; `config-reloader` sidecar (command-override poll loop, ARI PUT reload of `res_pjsip` / `res_pjsip_endpoint_identifier_ip` / `res_pjsip_outbound_registration` / `pbx_config`, change detection via `readlink ..data`).

## Inbound disambiguation (the load-bearing design decision)

Two accounts register to the **same** UniFi Talk IP, so IP-only `identify` is ambiguous. Belt-and-suspenders: keep `line=yes` **and** a per-account `identify` with `match` (server IP) + `match_header` (To-user regex). Unmatched INVITEs **fail-safe to rejection, never misroute**. The `match_header` regex is **provisional** pending a live INVITE capture (validation V2).

## ⚠️ Pre-merge prerequisite (do this first or the rollout wedges)

Merging syncs via ArgoCD → the Asterisk Deployment rolls (`Recreate`, drops any in-progress call — do it in a quiet window). The new `dynamic-config` volume is a **required** Secret mount, so the pod stays `ContainerCreating` until `dograh-asterisk-dynamic` exists — which requires ESO to have rendered it from 1P.

**Before merge:** add the `unifi_talk_accounts` field to the 1P `dograh` item, seeded with the **existing** account as `{"extension":"7000", ..., "primary":true}` (current creds). Confirm `kubectl -n dograh get secret dograh-asterisk-dynamic` has both keys non-empty.

## Validation gates (V1–V3 gate adding a 2nd line)

- **V1** — after the roll, 7000 registers and its DID answers via workflow 3, unchanged.
- **V2** — capture the inbound INVITE: does UniFi preserve `;line=`? what's in the To header (SIP username vs DID)? Adjust `match_header` to reality **before** adding 7001.
- **V3** — Dograh logs show `called_number=7000` → workflow 3.
- **V4/V5** — hot-add 7001, confirm it registers without restart and doesn't perturb 7000; dual same-source registration holds.

Full hardened plan (with rollback + residual risks) lives in session scratch; happy to paste on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
