### PR TITLE
chore(dograh): bump hermes-adapter to sha-4aa0f40 (session_id override)

### DIFF
--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/hermes-adapter/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: adapter
-          image: ghcr.io/jtcressy/dograh-hermes-adapter:sha-407e451@sha256:70cdb734244407881b481beb0821b5ffd30cbcd38fa1180d176d1b954ec93b97
+          image: ghcr.io/jtcressy/dograh-hermes-adapter:sha-4aa0f40@sha256:db289af83596aa7a62016264b7c1be1ca6253ea53b5c63f537de2f9ce4f28ed2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Single-line image digest bump picking up jtcressy/dograh-hermes-adapter#1 (optional `session_id` field on /ask overriding X-Hermes-Session-Id, enabling outbound-callback session continuity). Follow-up documented in #894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)