### PR TITLE
dograh-asterisk: make ESO template primary key optional (null-safe)

### DIFF
--- a/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/dograh/dograh/clusters/bastion/asterisk/externalsecret.yaml
@@ -99,7 +99,7 @@ spec:
           exten => _[0-9a-zA-Z+*#].,1,Goto({{ $a.extension }},1)
           {{- end }}
           {{- range $a := $accounts }}
-          {{- if $a.primary }}
+          {{- if index $a "primary" }}
 
           [from-dograh]
           exten => _X.,1,NoOp(Dograh outbound call to ${EXTEN} through UniFi Talk)


### PR DESCRIPTION
ESO (External Secrets Operator) runs its Go templates with `missingkey=error`. In the `dograh-asterisk-dynamic` ExternalSecret, the `extensions-inbound.conf` template ranges over the `unifi_talk_accounts` JSON array and guarded the outbound `[from-dograh]` context with `{{- if $a.primary }}`.

Because of `missingkey=error`, any account object in the array that lacks a `primary` key made the **entire** render error with `map has no entry for key primary`, and the Secret failed to update.

This already bit us in production: a newly added account without an explicit `primary: false` broke the render. The `mustFromJson` / last-good-retention fail-safe kept the live config serving, which is why nothing outwardly broke, but the Secret stopped reconciling.

## Fix

Replace the field access with a null-safe index lookup:

```
- {{- if $a.primary }}
+ {{- if index $a "primary" }}
```

`index $a "primary"` returns `nil` for a missing key instead of erroring, and `nil` is falsy. So an account without a `primary` key simply does not render the outbound context — which is the correct behavior (only the primary account gets `[from-dograh]`).

## Impact

Adding a non-primary UniFi Talk account is now a pure data edit — no required `primary` key. One-line change, no behavior change for existing accounts that set `primary` explicitly.

Validated: YAML parses (multi-doc) and `kubectl kustomize --enable-helm .../clusters/bastion` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)