### PR TITLE
feat(hermes): add VolSync restic backups for hermes-data PVC

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/README.md
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/README.md
@@ -131,3 +131,23 @@ browser tooling.
       (deleting and re-registering the client is the only recovery path).
    4. Revoke the `allow_dcr` grant afterward if it was added just for this
       one-time registration.
+
+## PVC backups (VolSync)
+
+`volsync.yaml` backs up the `hermes-data` PVC nightly (02:15) via a restic
+`ReplicationSource` to the shared R2 restic repository (1Password item
+`volsync-restic-template`), retaining 7 daily + 4 weekly snapshots. The
+repository suffix is `hermes-data` to keep it separate from the CNPG barman
+backups already stored under the `hermes/` prefix.
+
+Restore procedure (the live PVC predates VolSync, so it has no
+`dataSourceRef` bootstrap — restores are manual):
+
+1. Scale the `hermes` deployment to 0.
+2. Create a `ReplicationDestination` with `trigger.manual`, pointing at
+   `hermes-restic-secret` (see the metamcp overlay's `persistence.yaml` for
+   the shape).
+3. Recreate the PVC with `dataSourceRef` referencing that
+   `ReplicationDestination`, or copy the restored snapshot's contents onto a
+   fresh PVC.
+4. Scale the deployment back up.

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/kustomization.yaml
@@ -8,6 +8,7 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - hermes-pvc.yaml
+  - volsync.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/volsync.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/volsync.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-restic
+  labels:
+    app.kubernetes.io/name: hermes
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: hermes-restic-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # "hermes-data" (not "hermes") to avoid colliding with the CNPG barman
+        # backups already stored under the hermes/ prefix (see pg-cluster.yaml).
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/hermes-data"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-restic-template
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: hermes-data
+  labels:
+    app.kubernetes.io/name: hermes
+spec:
+  sourcePVC: hermes-data
+  trigger:
+    schedule: "15 2 * * *"
+  restic:
+    pruneIntervalDays: 7
+    repository: hermes-restic-secret
+    retain:
+      daily: 7
+      weekly: 4
+    copyMethod: Snapshot
+    storageClassName: zfs-nvme
+    volumeSnapshotClassName: zfs-nvme-snapshot


### PR DESCRIPTION
## Goal
Back up the `hermes-data` PVC (agent state.db, memories, skills, config, claude/codex auth) — currently unprotected; only the CNPG Postgres cluster has backups.

## Changes
- `volsync.yaml`: restic `ExternalSecret` (shared `volsync-restic-template` 1Password item) + `ReplicationSource` — nightly 02:15, retain 7 daily / 4 weekly, `copyMethod: Snapshot` on `zfs-nvme-snapshot` (same pattern as the metamcp overlay).
- Restic repository suffix is `hermes-data` (not `hermes`) to avoid colliding with CNPG barman backups already stored under the `hermes/` prefix.
- README: backup description + manual restore procedure. No `dataSourceRef` on the PVC — it's immutable on the live claim; restores are manual via a `ReplicationDestination`.

## Verification
1. After merge/sync: `kubectl get replicationsource -n hermes hermes-data` shows the schedule.
2. Trigger or await the 02:15 run; `status.lastSyncTime` populates and `restic snapshots` lists one snapshot under `.../hermes-data`.
3. Confirm CNPG barman backups still list correctly (no prefix collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)