### PR TITLE
feat(hermes): add GitHub App credentials to env template

### DIFF
--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/externalsecret.yaml
@@ -39,6 +39,12 @@ spec:
           CAMOFOX_URL=http://hermes-camofox.hermes.svc:9377
           CAMOFOX_API_KEY={{ .CAMOFOX_API_KEY }}
           METAMCP_API_KEY={{ .METAMCP_API_KEY }}
+          # GitHub App "hermes-agent" (installed on jtcressy + jtcressy-home).
+          # Consumed by /opt/data/.local/bin/gh-app-token to mint 1h
+          # installation tokens; the PEM is stored base64-encoded because
+          # dotenv values are single-line.
+          GITHUB_APP_ID={{ .GITHUB_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY_B64={{ .GITHUB_APP_PRIVATE_KEY_B64 }}
           DOGRAH_API_KEY={{ .DOGRAH_API_KEY }}
           DOGRAH_API_BASE_URL=http://dograh-api.dograh.svc.cluster.local:8000
   dataFrom:


### PR DESCRIPTION
## Goal
Give Hermes GitHub access via a single GitHub App (`hermes-agent`) instead of a PAT — 1h auto-expiring installation tokens, `hermes-agent[bot]` attribution, per-repo installation scoping.

## Changes
- `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_B64` added to the hermes `.env` ExternalSecret template.
- Token minting is handled by `/opt/data/.local/bin/gh-app-token` on the PVC (JWT → installation token, auto-discovers installations).

## Pre-merge checklist
- [ ] GitHub App `hermes-agent` created (owner: jtcressy, installable on any account)
- [ ] Installed on `jtcressy` (repo: keychains) and `jtcressy-home` (repo: infra)
- [ ] 1Password `hermes` item has `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_B64` fields
- Merging before the 1P fields exist breaks the ExternalSecret render (blocks .env refresh)

## Verification
1. ESO secret `hermes-env` re-renders without error after merge.
2. Rollout restart, then in-pod: `gh-app-token --list` shows both installations; `gh-app-token jtcressy-home` prints a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)