### PR TITLE
fix(argocd): prevent ApplicationSet cascade deletion; align hermes-db with post-incident recovery

### DIFF
--- a/kubernetes/argocd/appsets/apps.yaml
+++ b/kubernetes/argocd/appsets/apps.yaml
@@ -8,8 +8,15 @@ spec:
   # 'sync' (default): Allows create, update, and delete operations
   # This ensures git is the source of truth - when overlays move to disabled/,
   # the corresponding Applications are automatically deleted from ArgoCD
+  # preserveResourcesOnDeletion prevents Application deletion from cascading
+  # to workload resources (2026-07-13 incident: a malformed commit briefly
+  # emptied the repo and the ApplicationSet cascade-deleted live workloads,
+  # CNPG databases, and PVCs). Intentionally removing an app's resources now
+  # requires an explicit cascade delete after disabling the overlay:
+  #   kubectl delete application <app> -n argocd --cascade=foreground
   syncPolicy:
     applicationsSync: sync  # Changed from create-update
+    preserveResourcesOnDeletion: true
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy

--- a/kubernetes/argocd/appsets/cluster-cni.yaml
+++ b/kubernetes/argocd/appsets/cluster-cni.yaml
@@ -4,6 +4,11 @@ metadata:
   name: cluster-cni
   namespace: argocd
 spec:
+  # Never cascade-delete the CNI when an Application disappears (2026-07-13
+  # incident: a malformed commit briefly emptied the repo and cilium was
+  # cascade-deleted, breaking all pod networking).
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   goTemplate: true
   generators:
   - git:

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
@@ -20,7 +20,7 @@ spec:
   # 2026-07-13: cluster was destroyed in the ArgoCD cascade-deletion incident
   # and restored from the barman R2 backup. The bootstrap below reflects that
   # recovery (bootstrap is only consulted at cluster creation; CNPG ignores it
-  # afterwards). New WALs/backups archive under serverName hermes-db-v2 because
+  # afterwards). New WALs/backups archive under serverName hermes-db-v3 because
   # the original hermes-db archive lineage was terminated by the restore.
   bootstrap:
     recovery:
@@ -51,7 +51,7 @@ spec:
           encryption: AES256
   backup:
     barmanObjectStore:
-      serverName: hermes-db-v2
+      serverName: hermes-db-v3
       destinationPath: s3://restic-backups/hermes/
       endpointURL: https://5d4249bf326be62396b18a9f6000341b.r2.cloudflarestorage.com
       s3Credentials:

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
@@ -16,14 +16,37 @@ spec:
   # database `mem0` is owned by the `mem0` role; CNPG surfaces its credentials
   # in the generated `hermes-db-app` secret. pgvector (0.8.1, shipped in the
   # -system- image) is enabled at bootstrap as superuser in the app database.
+  #
+  # 2026-07-13: cluster was destroyed in the ArgoCD cascade-deletion incident
+  # and restored from the barman R2 backup. The bootstrap below reflects that
+  # recovery (bootstrap is only consulted at cluster creation; CNPG ignores it
+  # afterwards). New WALs/backups archive under serverName hermes-db-v2 because
+  # the original hermes-db archive lineage was terminated by the restore.
   bootstrap:
-    initdb:
-      database: mem0
-      owner: mem0
-      postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS vector
+    recovery:
+      source: hermes-db-backup
+  externalClusters:
+    - name: hermes-db-backup
+      barmanObjectStore:
+        serverName: hermes-db
+        destinationPath: s3://restic-backups/hermes/
+        endpointURL: https://5d4249bf326be62396b18a9f6000341b.r2.cloudflarestorage.com
+        s3Credentials:
+          accessKeyId:
+            name: hermes-cnpg-r2-secret
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKey:
+            name: hermes-cnpg-r2-secret
+            key: AWS_SECRET_ACCESS_KEY
+        wal:
+          compression: gzip
+          encryption: AES256
+        data:
+          compression: gzip
+          encryption: AES256
   backup:
     barmanObjectStore:
+      serverName: hermes-db-v2
       destinationPath: s3://restic-backups/hermes/
       endpointURL: https://5d4249bf326be62396b18a9f6000341b.r2.cloudflarestorage.com
       s3Credentials:

--- a/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
+++ b/kubernetes/deploy/agentic-ai/hermes/hermes/clusters/bastion/pg-cluster.yaml
@@ -25,6 +25,11 @@ spec:
   bootstrap:
     recovery:
       source: hermes-db-backup
+      # Without these, CNPG assumes the application database/user are `app`
+      # and will not manage credentials for the restored `mem0` role
+      # (https://cloudnative-pg.io/docs/1.28/recovery/#recovery-from-a-backup-object).
+      database: mem0
+      owner: mem0
   externalClusters:
     - name: hermes-db-backup
       barmanObjectStore:


### PR DESCRIPTION
## Context

On 2026-07-13 (~01:56Z) a malformed gitlink commit briefly deleted all files on `main` (~60s before revert). The push webhook delivered it to ArgoCD instantly; with `applicationsSync: sync`, the ApplicationSet cascade-deleted 22 Applications and their resources — including cilium (all pod networking), the tailscale operator, three CNPG postgres clusters, and app PVCs — before ArgoCD deleted itself and the cascade froze mid-flight.

Everything has been recovered (teslamate-db and dograh-db with zero data loss via PV rebind; hermes-db from its 00:00 barman R2 backup; app config PVCs from volsync restic backups). The incident timeline and full recovery record live in the private planning repo: `notes/2026-07-13-argocd-mass-deletion-incident.md`.

## Changes

- **`preserveResourcesOnDeletion: true`** on both ApplicationSets (`apps`, `cluster-cni`). Application CRs still track git exactly as before (create/update/delete), but deleting an Application orphans its resources instead of cascade-destroying them. A transient bad git state can never again take out live workloads, databases, or PVCs.
  - Workflow note: intentionally removing an app's resources after `task apps:overlays:disable` now needs an explicit `kubectl delete application <app> -n argocd --cascade=foreground` (or manual namespace cleanup). Consider folding that into the disable task as a follow-up.
- **hermes-db manifest aligned with its recovery**: bootstrap-from-barman (`hermes-db` lineage) and new archive `serverName: hermes-db-v2`, so ArgoCD stops diffing against the pre-incident `initdb` spec and WAL archiving stays healthy.

## Follow-up recommendations (not in this PR)

1. **Repo ruleset**: deny admin bypass for direct pushes to `main` — the malformed commit landed via "Bypassed rule violations". Direct pushes should be limited to the `.planning` gitlink bump case, which a ruleset can't distinguish, so consider requiring PRs strictly and moving gitlink bumps to a bot/exempt actor.
2. **teslamate-db**: pin `spec.superuserSecret` to the 1Password-sourced credential (like dograh-db does) so a recreated cluster can never generate a mismatched superuser password again.
3. Consider webhook-triggered syncs with a short `syncPolicy.retry` backoff or ApplicationSet `requeueAfterSeconds` to reduce blast speed of bad pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132SDM8g5RgBNU7GVYmWUD1