### PR TITLE
chore(renovate): group tailscale updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/\\.yaml$/"
+        "/\\.ya?ml$/"
       ],
       "matchStrings": [
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s  version: (?<currentValue>.*)\\s",
@@ -168,6 +168,18 @@
       "addLabels": [
         "renovate:automerge"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "tailscale/**",
+        "tailscale.com",
+        "tailscale-operator",
+        "ghcr.io/tailscale/**"
+      ],
+      "groupName": "tailscale",
+      "groupSlug": "tailscale",
+      "separateMajorMinor": false,
+      "automerge": false
     }
   ],
   "autoApprove": true,


### PR DESCRIPTION
## Summary

- detect Renovate version annotations in both `.yaml` and `.yml` files
- group Tailscale actions, client binaries, container images, Helm charts, and Go modules into one PR
- keep the consolidated Tailscale update out of automerge so the operator rollout can be validated deliberately

## Why

The custom regex manager only scanned `.yaml`, so the Tailscale client versions embedded in GitHub Actions `.yml` workflows were never updated. Those stale clients now fail Workload Identity Federation because Tailscale requires client 1.90.0 or newer.

## Validation

- `jq empty renovate.json`
- `git diff --check`
- `renovate-config-validator renovate.json`