### PR TITLE
fix(renovate): match indented workflow versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
         "/\\.ya?ml$/"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s  version: (?<currentValue>.*)\\s",
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+version:\\s+(?<currentValue>\\S+)",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\stalosVersion: (?<currentValue>.*)\\s",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\skubernetesVersion: (?<currentValue>.*)\\s",
         "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s    tag: (?<currentValue>.*)\\s"


### PR DESCRIPTION
## Summary

- make the custom `version:` regex tolerate YAML indentation
- allow Renovate to detect all four Tailscale client pins in GitHub Actions workflows

## Why

PR #913 enabled `.yml` scanning, but the inherited regex still required exactly two spaces before `version:`. GitHub Actions workflow inputs are indented further, so Renovate's first grouped run only found the Helm operator update.

## Validation

- loaded the regex directly from `renovate.json` and matched all four workflow pins
- `jq empty renovate.json`
- `git diff --check`
- `renovate@43.259.2 renovate-config-validator renovate.json`