### PR TITLE
fix(ci): authorize ArgoCD PR diff discovery

### DIFF
--- a/.taskfiles/apps/overlay/Taskfile.yaml
+++ b/.taskfiles/apps/overlay/Taskfile.yaml
@@ -202,7 +202,7 @@ tasks:
             exit $exitCode
           fi
     preconditions:
-      - sh: argocd app get "{{.appName}}"
+      - sh: argocd app get "{{.appName}}" --grpc-web
         msg: "App '{{.appName}}' not found in ArgoCD Server or not authorized. Check credentials or whether the app exists in ArgoCD."
   diff-pr:
     desc: "Run ArgoCD app diff for multiple apps, output as markdown (requires: apps as comma-separated list)"
@@ -245,13 +245,16 @@ tasks:
     silent: true
     vars:
       apps:
-        sh: argocd app list -o name
+        sh: argocd app list --grpc-web -o name
       outputFile: '{{ .outputFile | default (list .PROJECT_DIR ".local/diff-pr-all.md" | join "/") }}'
     cmds:
       - task: diff-pr
         vars:
-          apps: '{{.apps | splitLines | join ","}}'
+          apps: '{{.apps | trim | splitLines | join ","}}'
           outputFile: "{{.outputFile}}"
+    preconditions:
+      - sh: test -n "{{.apps | trim}}"
+        msg: "No ArgoCD applications were returned. Check credentials and gRPC-web connectivity."
   orphaned:
     desc: "List ArgoCD applications without corresponding enabled overlays in git"
     summary: |

--- a/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-cm.yaml
+++ b/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-cm.yaml
@@ -43,7 +43,7 @@ data:
         userIDKey: sub
         userNameKey: actor
         claimMapping:
-          groups: ref
+          groups: sub
   resource.customizations: |
     apiextensions.k8s.io_CustomResourceDefinition:
       syncOptions:

--- a/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-rbac-cm.yaml
+++ b/kubernetes/deploy/admin/argocd/argocd/clusters/bastion/argocd-rbac-cm.yaml
@@ -8,9 +8,9 @@ data:
     g, jtcressy@github, role:admin
     g, joel@jtcressy.net, role:admin
 
-    # Branch-based GitHub Actions groups
-    g, refs/heads/main, role:gh_actions_main
-    g, refs/pull/*, role:gh_actions_pr
+    # Repository-scoped GitHub Actions OIDC subjects
+    g, repo:jtcressy-home/infra:ref:refs/heads/main, role:gh_actions_main
+    g, repo:jtcressy-home/infra:pull_request, role:gh_actions_pr
 
     # gh_actions_main role (admin access for main branch)
     p, role:gh_actions_main, applications, *, */*, allow


### PR DESCRIPTION
## Summary

- map GitHub Actions' stable repository-scoped OIDC `sub` claim into Dex groups
- bind exact `main` and pull-request subjects to the existing ArgoCD roles
- keep pull requests read-only while preserving `main` administration
- use gRPC-web for app discovery/validation, normalize the app list, and reject an empty list clearly

## Why

The workflow now reaches ArgoCD, but its PR token has no effective role. Dex mapped the per-run `ref` claim while `argocd-rbac-cm` attempted a wildcard `g, refs/pull/*` role assignment; ArgoCD group-to-role assignments require an exact group. The unauthorized app list returned empty and the task previously converted that to `argocd app diff ""`.

## Validation

- `argocd admin settings rbac can`: PR get = yes, PR update = no, main update = yes
- `task apps:overlays:render project=admin namespace=argocd app=argocd cluster=bastion`
- full rendered overlay: `kubectl apply --dry-run=server` passed
- `task -l`
- mock newline-terminated two-app diff run completed exactly two non-empty diffs
- `git diff --check`

## Bootstrap note

This PR's ArgoCD check cannot use the new RBAC mapping until the change is merged and the live ArgoCD application syncs. After rollout, the original PR #912 will be refreshed to verify the complete path.