### PR TITLE
test(ci): expose constrained Claude review error [closed; do not merge]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,18 +46,9 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Reply with exactly OK. Do not inspect files, environment variables, or use tools.
+          show_full_output: true
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+          claude_args: '--max-turns 1'


### PR DESCRIPTION
Temporary diagnostic PR. Do not merge.

The Claude action currently returns `is_error:true` without exposing the provider error. This replaces the review prompt with a one-turn, no-tools `OK` response and enables full JSON output, preventing repository/tool content from entering the diagnostic log. The PR will be closed after the underlying error is captured.