### PR TITLE
ci: disable slow ArgoCD PR diff

### DIFF
--- a/.github/workflows/argocd-diff.yml
+++ b/.github/workflows/argocd-diff.yml
@@ -1,12 +1,12 @@
 name: ArgoCD Diff
 
-on:
-  pull_request:
-    branches:
-      - main
+# Disabled while a changed-app replacement is designed. The previous workflow
+# diffed every live ArgoCD application serially and took about 14 minutes per PR.
+on: workflow_dispatch
 
 jobs:
   argocd-diff:
+    if: ${{ false }}
     name: Generate ArgoCD Diff
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- remove the automatic `pull_request` trigger from the ArgoCD diff workflow
- retain a manual workflow entry point but hard-disable the job
- leave the implementation in place as a reference while its changed-app replacement is designed separately

## Why
The current job serially diffs all 60 live ArgoCD applications. A successful run took approximately 14 minutes, and a Renovate burst left 38 additional ArgoCD runs queued or executing. Those runs were canceled before opening this PR.

## Validation
- `yq eval '.on, .jobs.argocd-diff.if' .github/workflows/argocd-diff.yml`
- `git diff --check`

This PR intentionally disables the check; it does not replace it.