### PR TITLE
ci: disable duplicate Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,17 +1,11 @@
 name: Claude Code Review
 
-on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+# Disabled in favor of the repository's automatic Codex GitHub App reviews.
+on: workflow_dispatch
 
 jobs:
   claude-review:
+    if: ${{ false }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -60,4 +54,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-


### PR DESCRIPTION
## Summary
- remove the automatic `pull_request` trigger from the Claude Code Review workflow
- hard-disable manual execution of the job
- retain Codex's existing GitHub App reviews as the repository's automated AI review path

## Why
The Actions-based Claude reviewer is failing across the PR queue and duplicates the repository's already-enabled automatic Codex App reviews. It has been consuming runner capacity without producing usable review results.

## Validation
- `yq eval '.on, .jobs.claude-review.if' .github/workflows/claude-code-review.yml`
- `git diff --check`
- confirmed Codex reviews are posted by `chatgpt-codex-connector[bot]`

## Enforcement note
Codex currently posts a `COMMENTED` PR review, not a check run or `APPROVED` review. GitHub therefore does not expose a native Codex status context that can be selected as a required check.