### PR TITLE
ci: gate merges on Codex App review

### DIFF
--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -19,7 +19,7 @@ function findCodexSignal({
           candidate.state !== "DISMISSED",
       )
       .map((review) => ({
-        type: "findings",
+        type: "reviewed",
         createdAt: review.submitted_at,
       })),
     ...reactions
@@ -30,7 +30,7 @@ function findCodexSignal({
           Date.parse(candidate.created_at) >= triggeredAt,
       )
       .map((reaction) => ({
-        type: "approved",
+        type: "no-findings",
         createdAt: reaction.created_at,
       })),
   ];
@@ -138,16 +138,10 @@ async function run({ github, context, core }) {
     });
 
     if (signal) {
-      if (signal.type === "findings") {
-        const description = "Codex posted findings on this PR head";
-        await setStatus("failure", description);
-        core.setFailed(
-          "Address Codex findings, resolve every review thread, and push a new head for another review.",
-        );
-        return;
-      }
-
-      const description = "Codex reported no findings on this PR update";
+      const description =
+        signal.type === "reviewed"
+          ? "Codex reviewed this PR head; resolve any findings"
+          : "Codex reported no findings on this PR update";
       await setStatus("success", description);
       core.info(`${description} at ${signal.createdAt}`);
       core.setOutput("signal", signal.type);

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -1,0 +1,134 @@
+const DEFAULT_BOT_LOGIN = "chatgpt-codex-connector[bot]";
+const DEFAULT_CONTEXT = "Codex Review Gate";
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 8 * 60_000;
+
+function findCodexSignal({
+  reviews,
+  reactions,
+  headSha,
+  triggeredAt,
+  botLogin = DEFAULT_BOT_LOGIN,
+}) {
+  const review = reviews.find(
+    (candidate) =>
+      candidate.user?.login === botLogin &&
+      candidate.commit_id === headSha &&
+      candidate.state !== "DISMISSED",
+  );
+
+  if (review) {
+    return { type: "review", createdAt: review.submitted_at };
+  }
+
+  const reaction = reactions.find(
+    (candidate) =>
+      candidate.user?.login === botLogin &&
+      candidate.content === "+1" &&
+      Date.parse(candidate.created_at) >= triggeredAt,
+  );
+
+  if (reaction) {
+    return { type: "no-findings", createdAt: reaction.created_at };
+  }
+
+  return null;
+}
+
+async function run({ github, context, core }) {
+  const pullRequest = context.payload.pull_request;
+  if (!pullRequest) {
+    throw new Error("Codex review gate requires a pull_request_target event");
+  }
+
+  const { owner, repo } = context.repo;
+  const pullNumber = pullRequest.number;
+  const headSha = pullRequest.head.sha;
+  const statusContext = process.env.CODEX_STATUS_CONTEXT || DEFAULT_CONTEXT;
+  const botLogin = process.env.CODEX_BOT_LOGIN || DEFAULT_BOT_LOGIN;
+  const pollIntervalMs = Number(
+    process.env.CODEX_POLL_INTERVAL_MS || DEFAULT_POLL_INTERVAL_MS,
+  );
+  const timeoutMs = Number(process.env.CODEX_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
+  const eventTimestamp =
+    Date.parse(pullRequest.updated_at || pullRequest.created_at) - 1_000;
+  const deadline = Date.now() + timeoutMs;
+  const targetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+  const setStatus = (state, description) =>
+    github.rest.repos.createCommitStatus({
+      owner,
+      repo,
+      sha: headSha,
+      state,
+      context: statusContext,
+      description,
+      target_url: targetUrl,
+    });
+
+  await setStatus("pending", "Waiting for Codex App review");
+
+  while (Date.now() < deadline) {
+    const { data: currentPullRequest } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+
+    if (currentPullRequest.head.sha !== headSha) {
+      core.info("PR head changed; a newer gate run will evaluate the new head");
+      return;
+    }
+
+    if (currentPullRequest.state !== "open") {
+      core.info("PR is no longer open; no merge gate is needed");
+      return;
+    }
+
+    const [reviews, reactions] = await Promise.all([
+      github.paginate(github.rest.pulls.listReviews, {
+        owner,
+        repo,
+        pull_number: pullNumber,
+        per_page: 100,
+      }),
+      github.paginate(github.rest.reactions.listForIssue, {
+        owner,
+        repo,
+        issue_number: pullNumber,
+        per_page: 100,
+      }),
+    ]);
+
+    const signal = findCodexSignal({
+      reviews,
+      reactions,
+      headSha,
+      triggeredAt: eventTimestamp,
+      botLogin,
+    });
+
+    if (signal) {
+      const description =
+        signal.type === "review"
+          ? "Codex reviewed the current PR head"
+          : "Codex reported no findings on this PR update";
+      await setStatus("success", description);
+      core.info(`${description} at ${signal.createdAt}`);
+      core.setOutput("signal", signal.type);
+      return;
+    }
+
+    core.info(`No completed Codex review signal yet; polling again in ${pollIntervalMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  await setStatus("failure", "Codex did not complete review within 8 minutes");
+  core.setFailed(
+    "Timed out waiting for Codex. Re-request review with '@codex review', then rerun this job.",
+  );
+}
+
+module.exports = run;
+module.exports.findCodexSignal = findCodexSignal;
+

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -18,7 +18,7 @@ function findCodexSignal({
   );
 
   if (review) {
-    return { type: "review", createdAt: review.submitted_at };
+    return { type: "findings", createdAt: review.submitted_at };
   }
 
   const reaction = reactions.find(
@@ -29,7 +29,7 @@ function findCodexSignal({
   );
 
   if (reaction) {
-    return { type: "no-findings", createdAt: reaction.created_at };
+    return { type: "approved", createdAt: reaction.created_at };
   }
 
   return null;
@@ -109,10 +109,16 @@ async function run({ github, context, core }) {
     });
 
     if (signal) {
-      const description =
-        signal.type === "review"
-          ? "Codex reviewed the current PR head"
-          : "Codex reported no findings on this PR update";
+      if (signal.type === "findings") {
+        const description = "Codex posted findings on this PR head";
+        await setStatus("failure", description);
+        core.setFailed(
+          "Address Codex findings, resolve every review thread, and push a new head for another review.",
+        );
+        return;
+      }
+
+      const description = "Codex reported no findings on this PR update";
       await setStatus("success", description);
       core.info(`${description} at ${signal.createdAt}`);
       core.setOutput("signal", signal.type);
@@ -131,4 +137,3 @@ async function run({ github, context, core }) {
 
 module.exports = run;
 module.exports.findCodexSignal = findCodexSignal;
-

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -85,7 +85,7 @@ async function run({ github, context, core }) {
       return;
     }
 
-    const [reviews, reactions] = await Promise.all([
+    const [reviews, issueReactions, comments] = await Promise.all([
       github.paginate(github.rest.pulls.listReviews, {
         owner,
         repo,
@@ -98,7 +98,30 @@ async function run({ github, context, core }) {
         issue_number: pullNumber,
         per_page: 100,
       }),
+      github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: pullNumber,
+        per_page: 100,
+      }),
     ]);
+
+    const reviewRequestComments = comments.filter(
+      (comment) =>
+        Date.parse(comment.created_at) >= eventTimestamp &&
+        /@codex\s+review\b/i.test(comment.body || ""),
+    );
+    const reviewRequestReactionPages = await Promise.all(
+      reviewRequestComments.map((comment) =>
+        github.paginate(github.rest.reactions.listForIssueComment, {
+          owner,
+          repo,
+          comment_id: comment.id,
+          per_page: 100,
+        }),
+      ),
+    );
+    const reactions = issueReactions.concat(...reviewRequestReactionPages);
 
     const signal = findCodexSignal({
       reviews,

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -10,29 +10,35 @@ function findCodexSignal({
   triggeredAt,
   botLogin = DEFAULT_BOT_LOGIN,
 }) {
-  const review = reviews.find(
-    (candidate) =>
-      candidate.user?.login === botLogin &&
-      candidate.commit_id === headSha &&
-      candidate.state !== "DISMISSED",
+  const signals = [
+    ...reviews
+      .filter(
+        (candidate) =>
+          candidate.user?.login === botLogin &&
+          candidate.commit_id === headSha &&
+          candidate.state !== "DISMISSED",
+      )
+      .map((review) => ({
+        type: "findings",
+        createdAt: review.submitted_at,
+      })),
+    ...reactions
+      .filter(
+        (candidate) =>
+          candidate.user?.login === botLogin &&
+          candidate.content === "+1" &&
+          Date.parse(candidate.created_at) >= triggeredAt,
+      )
+      .map((reaction) => ({
+        type: "approved",
+        createdAt: reaction.created_at,
+      })),
+  ];
+
+  return (
+    signals.sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))[0] ||
+    null
   );
-
-  if (review) {
-    return { type: "findings", createdAt: review.submitted_at };
-  }
-
-  const reaction = reactions.find(
-    (candidate) =>
-      candidate.user?.login === botLogin &&
-      candidate.content === "+1" &&
-      Date.parse(candidate.created_at) >= triggeredAt,
-  );
-
-  if (reaction) {
-    return { type: "approved", createdAt: reaction.created_at };
-  }
-
-  return null;
 }
 
 async function run({ github, context, core }) {

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -7,7 +7,6 @@ function findCodexSignal({
   reviews,
   reactions,
   headSha,
-  triggeredAt,
   botLogin = DEFAULT_BOT_LOGIN,
 }) {
   const signals = [
@@ -26,8 +25,7 @@ function findCodexSignal({
       .filter(
         (candidate) =>
           candidate.user?.login === botLogin &&
-          candidate.content === "+1" &&
-          Date.parse(candidate.created_at) >= triggeredAt,
+          candidate.content === "+1",
       )
       .map((reaction) => ({
         type: "no-findings",
@@ -56,8 +54,6 @@ async function run({ github, context, core }) {
     process.env.CODEX_POLL_INTERVAL_MS || DEFAULT_POLL_INTERVAL_MS,
   );
   const timeoutMs = Number(process.env.CODEX_TIMEOUT_MS || DEFAULT_TIMEOUT_MS);
-  const eventTimestamp =
-    Date.parse(pullRequest.updated_at || pullRequest.created_at) - 1_000;
   const deadline = Date.now() + timeoutMs;
   const targetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
@@ -73,6 +69,14 @@ async function run({ github, context, core }) {
     });
 
   await setStatus("pending", "Waiting for Codex App review");
+
+  const { data: reviewRequest } = await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    body: `@codex review\n\n<!-- codex-review-gate head=${headSha} run=${context.runId} -->`,
+  });
+  core.info(`Requested Codex review for ${headSha} in comment ${reviewRequest.id}`);
 
   while (Date.now() < deadline) {
     const { data: currentPullRequest } = await github.rest.pulls.get({
@@ -91,49 +95,25 @@ async function run({ github, context, core }) {
       return;
     }
 
-    const [reviews, issueReactions, comments] = await Promise.all([
+    const [reviews, reactions] = await Promise.all([
       github.paginate(github.rest.pulls.listReviews, {
         owner,
         repo,
         pull_number: pullNumber,
         per_page: 100,
       }),
-      github.paginate(github.rest.reactions.listForIssue, {
+      github.paginate(github.rest.reactions.listForIssueComment, {
         owner,
         repo,
-        issue_number: pullNumber,
-        per_page: 100,
-      }),
-      github.paginate(github.rest.issues.listComments, {
-        owner,
-        repo,
-        issue_number: pullNumber,
+        comment_id: reviewRequest.id,
         per_page: 100,
       }),
     ]);
-
-    const reviewRequestComments = comments.filter(
-      (comment) =>
-        Date.parse(comment.created_at) >= eventTimestamp &&
-        /@codex\s+review\b/i.test(comment.body || ""),
-    );
-    const reviewRequestReactionPages = await Promise.all(
-      reviewRequestComments.map((comment) =>
-        github.paginate(github.rest.reactions.listForIssueComment, {
-          owner,
-          repo,
-          comment_id: comment.id,
-          per_page: 100,
-        }),
-      ),
-    );
-    const reactions = issueReactions.concat(...reviewRequestReactionPages);
 
     const signal = findCodexSignal({
       reviews,
       reactions,
       headSha,
-      triggeredAt: eventTimestamp,
       botLogin,
     });
 

--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -15,7 +15,9 @@ function findCodexSignal({
         (candidate) =>
           candidate.user?.login === botLogin &&
           candidate.commit_id === headSha &&
-          candidate.state !== "DISMISSED",
+          candidate.state !== "DISMISSED" &&
+          candidate.state !== "PENDING" &&
+          Boolean(candidate.submitted_at),
       )
       .map((review) => ({
         type: "reviewed",

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - name: Wait for Codex App review
+      - name: Require Codex no-findings result
         uses: actions/github-script@v8
         env:
           CODEX_BOT_LOGIN: chatgpt-codex-connector[bot]

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -4,21 +4,23 @@ name: Codex Review Gate
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
-  group: codex-review-gate-${{ github.event.pull_request.number }}
+  group: codex-review-gate-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
   statuses: write
 
 jobs:
   gate:
     name: Publish Codex review status
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'pull_request_target' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -39,3 +41,21 @@ jobs:
           script: |
             const gate = require('./.github/scripts/codex-review-gate.js');
             await gate({ github, context, core });
+
+  merge-group:
+    name: Publish Codex merge-queue status
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark reviewed PRs ready for merge validation
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.merge_group.head_sha,
+              state: 'success',
+              context: 'Codex Review Gate',
+              description: 'PR heads completed Codex review before entering merge queue',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - name: Require Codex no-findings result
+      - name: Wait for Codex review completion
         uses: actions/github-script@v8
         env:
           CODEX_BOT_LOGIN: chatgpt-codex-connector[bot]

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -1,0 +1,41 @@
+name: Codex Review Gate
+
+# Use the trusted default-branch workflow and never check out pull request code.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: codex-review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  gate:
+    name: Publish Codex review status
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out trusted gate implementation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Wait for Codex App review
+        uses: actions/github-script@v8
+        env:
+          CODEX_BOT_LOGIN: chatgpt-codex-connector[bot]
+          CODEX_STATUS_CONTEXT: Codex Review Gate
+          CODEX_POLL_INTERVAL_MS: "15000"
+          CODEX_TIMEOUT_MS: "480000"
+        with:
+          script: |
+            const gate = require('./.github/scripts/codex-review-gate.js');
+            await gate({ github, context, core });

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Check out trusted gate implementation
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Wait for Codex review completion


### PR DESCRIPTION
## Summary
- publish a pending `Codex Review Gate` status on every non-draft PR head
- complete the status after Codex either posts a review tied to that exact head SHA or posts a new no-findings 👍 for that PR update
- reject stale reviews and stale reactions from older PR updates
- recognize both automatic PR reactions and reactions to explicit `@codex review` requests
- fail closed after eight minutes and cancel obsolete runs when the PR head changes

## Merge policy
After this PR merges, two independent protections apply:

1. **Codex Review Gate** requires proof that Codex completed a pass on the current PR head. A review with findings and a no-findings 👍 both satisfy review completion.
2. **Require conversation resolution** blocks merge while any review thread remains unresolved, including findings from older heads.

Therefore a new head cannot merge before Codex reviews it, and no old or current finding can be ignored without explicitly resolving its conversation.

## Security
The workflow uses `pull_request_target` but never checks out or executes pull-request code. It checks out the base SHA with persisted credentials disabled and grants only read metadata plus commit-status write access.

## Validation
- JavaScript syntax check
- signal tests for current/stale reviews and current/stale PR/comment reactions
- workflow YAML field validation
- `git diff --check`

The protection changes will be applied only after this final head receives Codex's own review-completion signal and is merged.