### PR TITLE
fix(kagent): use SSA for CRDs

### DIFF
--- a/kubernetes/deploy/agentic-ai/kagent/kagent/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/agentic-ai/kagent/kagent/clusters/bastion/kustomization.yaml
@@ -11,12 +11,22 @@ resources:
 helmCharts:
   - name: kagent-crds
     repo: oci://ghcr.io/kagent-dev/kagent/helm
-    version: 0.9.9
+    version: 0.9.11
     releaseName: kagent-crds
     namespace: kagent
   - name: kagent
     repo: oci://ghcr.io/kagent-dev/kagent/helm
-    version: 0.9.9
+    version: 0.9.11
     releaseName: kagent
     namespace: kagent
     valuesFile: values.yaml
+
+patches:
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+        value: ServerSideApply=true


### PR DESCRIPTION
## What changed

- update both `kagent` and `kagent-crds` from `0.9.9` to `0.9.11`
- annotate every rendered KAgent CRD with `argocd.argoproj.io/sync-options: ServerSideApply=true`

## Why

The initial KAgent rollout is degraded because Argo CD client-side apply cannot create `agents.kagent.dev` or `sandboxagents.kagent.dev`; their generated `kubectl.kubernetes.io/last-applied-configuration` annotations exceed Kubernetes' 262144-byte annotation limit. The controller then crash-loops because those APIs are absent, while the UI still loads through Tailscale.

The existing `argocd-cm` `resource.customizations` entry for CRD `syncOptions` does not take effect in Argo CD v3.2.1 because `ResourceOverride` does not support a `syncOptions` field. This overlay-level patch follows the existing CNPG, OpenClaw operator, Grafana operator, and VictoriaMetrics operator patterns in this repo.

This also incorporates the version changes from Renovate PRs #922 and #923.

## Validation

- `task --silent apps:overlays:render project=agentic-ai namespace=kagent app=kagent cluster=bastion`
- confirmed all 9 rendered CRDs carry `ServerSideApply=true`
- confirmed KAgent controller/UI and ModelConfig render at `0.9.11`
- confirmed OpenRouter ModelConfig, CNPG, Tailscale ingress, and disabled QueryDoc/Grafana MCP settings remain intact
- strict live Kubernetes API server-side dry-run passed for the rendered resources
- `git diff --check`
