### PR TITLE
fix(renovate): restore automatic app updates

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,69 @@
+name: Renovate auto-approve
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+permissions: {}
+
+concurrency:
+  group: renovate-auto-approve-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  approve:
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'renovate:automerge')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Verify every changed file is allowlisted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          files="$(
+            gh api --paginate \
+              "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+              --jq '.[].filename'
+          )"
+
+          if [[ -z "${files}" ]]; then
+            echo "No changed files found; refusing approval." >&2
+            exit 1
+          fi
+
+          while IFS= read -r file; do
+            case "${file}" in
+              kubernetes/deploy/agentic-ai/dograh/dograh/clusters/*/app/*.yaml | \
+              kubernetes/deploy/agentic-ai/hermes/hermes/clusters/*/deployment.yaml | \
+              kubernetes/deploy/home/media/*/clusters/*/*.yaml)
+                ;;
+              *)
+                echo "Refusing approval: ${file} is outside the automerge allowlist." >&2
+                exit 1
+                ;;
+            esac
+          done <<< "${files}"
+
+      - name: Approve Renovate pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api --method POST \
+            "/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            -f event=APPROVE \
+            -f body="Automatically approved: Renovate automerge PR changed only allowlisted application files."

--- a/renovate.json
+++ b/renovate.json
@@ -105,6 +105,24 @@
     },
     {
       "matchFileNames": [
+        "kubernetes/deploy/agentic-ai/hermes/**"
+      ],
+      "matchPackageNames": [
+        "nousresearch/hermes-agent"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "addLabels": [
+        "renovate:automerge"
+      ]
+    },
+    {
+      "matchFileNames": [
         ".taskfiles/**"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## What

- add an exact `nousresearch/hermes-agent` automerge rule for the Hermes deployment
- add a no-checkout `pull_request_target` workflow that approves Renovate PRs only when they:
  - are authored by `renovate[bot]`
  - originate from this repository
  - carry `renovate:automerge`
  - change only allowlisted Dograh, Hermes, or home-media YAML paths
- preserve the existing Dograh and broad home-media automerge rules

## Why

Renovate still marks Dograh and media PRs for automerge, but `main` now requires an approving review. Renovate is permitted to update the branch but cannot satisfy that review itself, so automerge-enabled PRs remain blocked. Hermes also had no automerge package rule.

The workflow restores the approval path without granting Renovate a repository-wide review bypass. It never checks out or executes pull-request code and receives only `pull-requests: write`.

## Validation

- `jq empty renovate.json`
- Renovate 43.280.0: config validated successfully
- `yq eval` workflow parse
- `actionlint` clean
- `git diff --check`
- allowlist checked against current Hermes PR #896, Dograh PR #938, and grouped media PR #829

## Rollout

After merge, hosted Renovate should relabel/rebase the existing PRs. The workflow will approve eligible PRs on `synchronize` or `labeled`, allowing Renovate's existing automerge behavior to complete once its normal checks pass.