### PR TITLE
feat: deploy SimplyPrint client

### DIFF
--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -47,6 +47,7 @@ jobs:
             case "${file}" in
               kubernetes/deploy/agentic-ai/dograh/dograh/clusters/*/app/*.yaml | \
               kubernetes/deploy/agentic-ai/hermes/hermes/clusters/*/deployment.yaml | \
+              kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/*/deployment.yaml | \
               kubernetes/deploy/home/media/*/clusters/*/*.yaml)
                 ;;
               *)

--- a/kubernetes/argocd/projects/home.yaml
+++ b/kubernetes/argocd/projects/home.yaml
@@ -33,6 +33,9 @@ spec:
     - name: '*'
       namespace: searxng
       server: '*'
+    - name: '*'
+      namespace: simplyprint
+      server: '*'
   namespaceResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/deployment.yaml
+++ b/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplyprint-client
+  labels:
+    app.kubernetes.io/name: simplyprint-client
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: simplyprint-client
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [
+            {
+              "name": "macvlan-conf-dhcp",
+              "namespace": "kube-system",
+              "interface": "eth1",
+              "mac": "02:73:69:6d:70:01"
+            }
+          ]
+      labels:
+        app.kubernetes.io/name: simplyprint-client
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: simplyprint-client
+          image: docker.io/simplyprint/simplyprint-client:production-stable@sha256:28da6181e25ac4c1b1208330d2d492bb34c4e49ef783c24a8dce45f76737693a
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: false
+          volumeMounts:
+            - name: config
+              mountPath: /root/.config/SimplyPrint
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: simplyprint-client

--- a/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/kustomization.yaml
+++ b/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - persistence.yaml
+  - service.yaml

--- a/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/persistence.yaml
+++ b/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/persistence.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: simplyprint-client
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: zfs-nvme

--- a/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/service.yaml
+++ b/kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/bastion/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplyprint-client
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: simplyprint-client
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/renovate.json
+++ b/renovate.json
@@ -123,6 +123,24 @@
     },
     {
       "matchFileNames": [
+        "kubernetes/deploy/home/simplyprint/simplyprint-client/clusters/*/deployment.yaml"
+      ],
+      "matchPackageNames": [
+        "docker.io/simplyprint/simplyprint-client"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true,
+      "addLabels": [
+        "renovate:automerge"
+      ]
+    },
+    {
+      "matchFileNames": [
         ".taskfiles/**"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## What changed

- allow the `simplyprint` namespace in the Home ArgoCD AppProject
- add the enabled `simplyprint-client-bastion` overlay
- run one persistent SimplyPrint Client with `Recreate` strategy
- pin the official `production-stable` image to the current immutable digest
- persist client configuration on a 1 GiB `zfs-nvme` PVC
- expose the local UI on TCP 8000
- attach `kube-system/macvlan-conf-dhcp` as `eth1` with stable MAC `02:73:69:6d:70:01`
- allowlist only the SimplyPrint deployment and image for Renovate auto-approval and automerge, including digest updates

## Why

The client provides one always-on bridge for the Anycubic Kobra S1 now and additional LAN printers later. The Multus interface gives it direct layer-2 LAN presence for discovery without adding host networking, a new NetworkAttachmentDefinition, or printer-side firmware changes.

Credentials, account pairing, and printer configuration remain outside Git. Future SimplyPrint image-update PRs are automatically approved and merged after required checks pass; they do not require manual review.

## Validation

- confirmed the live Multus attachment is present and its Argo application is Synced/Healthy
- confirmed `zfs-nvme` and the amd64 cluster node
- re-resolved the official image digest immediately before commit
- rendered through `task apps:overlays:render`
- parsed all rendered YAML and the embedded Multus JSON
- verified exactly one Deployment, Service, and PVC, with one replica, port 8000, the expected mount, and the expected network attachment
- Kubernetes server-side dry-run passed for the workload and Home AppProject
- the workload dry-run emits the expected restricted-PodSecurity warning because the official image has no non-root user and declares a root-owned config path; admission still accepts it, with capabilities dropped, privilege escalation disabled, and RuntimeDefault seccomp
- `task apps:overlays:diff-pr-test` passed all 8 tests
- Renovate's official config validator passed
- Renovate local extraction matched `docker.io/simplyprint/simplyprint-client` in only the intended deployment path
- parsed the auto-approval workflow YAML
- `git diff --check` passed

## Review and rollout boundary

This PR is ready for review but must not be merged or rolled out as part of this task.

## Post-merge checklist

1. Confirm the live Home AppProject contains the `simplyprint` destination.
2. Confirm `simplyprint-client-bastion` reaches Synced/Healthy.
3. Confirm the PVC is Bound and the pod is running.
4. Read the Multus `network-status` annotation and confirm `eth1` received a home-LAN DHCP address with MAC `02:73:69:6d:70:01`.
5. Open `http://<LAN-IP>:8000`.
6. Pair the SimplyPrint account and add the Kobra S1 through the UI.
7. Let subsequent SimplyPrint image-update PRs auto-approve and automerge after checks; no manual review is expected.